### PR TITLE
Automate flowtorch pypi release

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,8 +11,10 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    outputs:
+      has_updated: ${{ steps.version.outputs.has_updated }}
+      version_tag: ${{ steps.version.outputs.version_tag }}
     strategy:
       matrix:
         python-version: ['3.6', '3.7', '3.8']
@@ -62,3 +64,55 @@ jobs:
         cd docs
         sphinx-apidoc -o source ../flowtorch/
         make html
+    - name: See if a tag exists for the current version
+      id: version
+      run: |
+        VERSION_TAG="v$(python setup.py --version)"
+        if  [[ $(git ls-remote --tags origin refs/tags/$VERSION_TAG) ]]; then
+          # there exists a tag with same name as current version
+          echo "::set-output name=has_updated::false"
+        else
+          echo "::set-output name=has_updated::true"
+        fi
+        echo "::set-output name=version_tag::$(echo $VERSION_TAG)"
+        echo "The current version is $VERSION_TAG"
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    # check the current repository so the pypi release workflow won't be run on forks
+    if: github.event_name == 'push' && github.repository == 'facebookincubator/flowtorch' && needs.build.outputs.has_updated == 'true'
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Upgrade pip
+      run: python -m pip install --upgrade pip
+
+    - name: Install package dependencies
+      run: pip install setuptools wheel
+
+    - name: Build source distribution
+      run: python setup.py sdist
+
+    - name: Build Python 3 wheel
+      run: python setup.py bdist_wheel
+
+    - name: Upload to PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.PYPI_PASSWORD }}
+
+    - name: Create new release on GitHub
+      uses: actions/create-release@v1
+      with:
+        tag_name: ${{ needs.build.outputs.version_tag }}
+        release_name: ${{ needs.build.outputs.version_tag }}
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Summary: Release new pypi packages on new commits so we can change flowtorch dependencies from within beanmachine without manually cutting releases

Differential Revision: D27140269

