### PR TITLE
Publish only on tagged releases

### DIFF
--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -1,13 +1,8 @@
 name: Deploy On Release
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
-  # TODO: swap this in after verifying
-  # release:
-  #   types: [created]
+  release:
+    types: [created]
 
 jobs:
   tests-and-coverage-pip:
@@ -48,8 +43,6 @@ jobs:
     name: Release to pypi.org
     runs-on: ubuntu-latest
     needs: tests-and-coverage-pip
-    # TODO: remove this guard after verifying on test pypi
-    if: github.event_name == 'push' && github.repository == 'facebookincubator/flowtorch'
     strategy:
       fail-fast: true
     steps:


### PR DESCRIPTION
Summary: Pypi push failing because of versioning; I think setuptools-scm clobbers the tag if the workflow is not gated on a tagged release. Let's give this a shot...

Differential Revision: D28447491

