### PR TITLE
Fetch tags in gh action release workflow

### DIFF
--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -48,6 +48,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:


### PR DESCRIPTION
### Motivation

We are bitten by https://github.com/actions/checkout/issues/100 [yet again](https://github.com/facebookresearch/pplbench/pull/52), so lets just fetch the tags during checkout.

### Changes proposed

Fetch tags during `actions/checkout`

### Test Plan

https://github.com/facebookincubator/flowtorch/runs/2586537945?check_suite_focus=true
