### PR TITLE
Use facebookincubator links in docs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     url="https://flowtorch.ai/users",
     project_urls={
         "Documentation": "https://flowtorch.ai/users",
-        "Source": "https://www.github.com/stefanwebb/flowtorch",
+        "Source": "https://www.github.com/facebookincubator/flowtorch",
     },
     keywords=[
         "Deep Learning",

--- a/website/README.md
+++ b/website/README.md
@@ -1,18 +1,17 @@
-<img src="https://github.com/stefanwebb/flowtorch/raw/master/website/flowtorch-ai.png" width="100%" />
+<img src="https://github.com/facebookincubator/flowtorch/raw/master/gh-pages/flowtorch-ai.png" width="100%" />
 
-This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator, and hosted using GitHub pages at [https://flowtorch.ai](https://flowtorch.ai). The source for the website is located in [master/website](https://github.com/stefanwebb/flowtorch/tree/master/website) and it is hosted from the root directory of the [website](https://github.com/stefanwebb/flowtorch/tree/website) branch.
+This website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator, and hosted using GitHub pages at [https://flowtorch.ai](https://flowtorch.ai). The source for the website is located in [master/website](https://github.com/facebookincubator/flowtorch/tree/master/website) and it is hosted from the root directory of the [website](https://github.com/facebookincubator/flowtorch/tree/website) branch.
 
 ## Preparation
 1. Install [Node.js](https://nodejs.org/).
-2. Install [Yarn](https://yarnpkg.com/):
+1. Install [Yarn](https://yarnpkg.com/):
 ```console
 npm install --global yarn
 ```
-3. Install [Docusaurus 2](https://v2.docusaurus.io/docs/installation).
-4. Navigate to [master/website](https://github.com/stefanwebb/flowtorch/tree/master/website) and install the dependencies:
+1. Navigate to [master/website](https://github.com/facebookincubator/flowtorch/tree/master/website) and install the dependencies:
 ```console
 cd website
-yarn install
+yarn
 ```
 
 ## Local Development
@@ -29,48 +28,14 @@ This command starts a local development server and open up a browser window. Mos
 yarn build
 ```
 
-This command generates static content into the `website/build` directory, which is deployed by copying into the [website](https://github.com/stefanwebb/flowtorch/tree/website) branch.
+This command generates static content into the `website/build` directory.
 
 ## Deployment
 
-Core developers can deploy the website as follows. On Linux/Mac, in the base directory:
-
-> :exclamation: **The following commands for Linux/Mac have not yet been tested and debugged.**
+Core developers can deploy the website as follows.
 
 ```console
-git checkout master
-rm -r .website
-cd website
-yarn build
-cp -r build/* ../.website
-git checkout website
-git rm -r .
-cp -r .website/* .
-git add .
-git commit -a -m "Updating website"
-git push
-git checkout master
+GIT_USER=<Your GitHub username> USE_SSH=true yarn deploy
 ```
 
-Or on Windows:
-```console
-git checkout master
-rmdir /q /s website\build
-cd website
-yarn install
-yarn build
-cd ..
-git checkout website
-echo website/ > .gitignore
-git clean -f -d
-del .gitignore
-git rm -r .
-xcopy /E /I website\build .
-git add .
-git commit -a -m "Updating website"
-git push
-git checkout master
-rmdir /q /s website\build
-```
-
-Activity logs for all past deployments to GitHub pages can be viewed [here](https://github.com/stefanwebb/flowtorch/deployments/activity_log?environment=github-pages). For your convenience, there is [a script to deploy the website on Windows](https://github.com/stefanwebb/flowtorch/tree/master/deploy-website-windows.bat).
+Activity logs for all past deployments to GitHub pages can be viewed [here](https://github.com/facebookincubator/flowtorch/deployments/activity_log?environment=github-pages). For your convenience, there is [a script to deploy the website on Windows](https://github.com/facebookincubator/flowtorch/tree/master/deploy-website-windows.bat).

--- a/website/docs/dev/building.md
+++ b/website/docs/dev/building.md
@@ -15,7 +15,7 @@ SW: I am unfamiliar with `setuptools_scm` and am unsure whether we should define
 git tag <version>
 git push
 ```
-2. Make release notes and add to [GitHub releases](https://github.com/stefanwebb/flowtorch/releases).
+2. Make release notes and add to [GitHub releases](https://github.com/facebookincubator/flowtorch/releases).
 3. Build the wheel and test that the package description will render correctly on PyPI:
 ```bash
 python setup.py sdist bdist_wheel
@@ -26,7 +26,7 @@ twine check dist/*
 twine upload dist/*
 ```
 5. Make release announcements on:
-    *  [PyTorch Slack](pytorch.slack.com) channels `#normalizing_flows`, `#pyro`, and `#announcements`
+    *  [PyTorch Slack](https://pytorch.slack.com) channels `#normalizing_flows`, `#pyro`, and `#announcements`
     * Personal account on Facebook
     * Personal account on Twitter
     * Personal account on LinkedIn

--- a/website/docs/dev/code_of_conduct.md
+++ b/website/docs/dev/code_of_conduct.md
@@ -4,7 +4,7 @@ title: Code of Conduct
 sidebar_label: Code of Conduct
 ---
 
-As a contributor, you agree to abide by the [Contributor Covenant Code of Conduct](https://github.com/stefanwebb/flowtorch/blob/master/CODE_OF_CONDUCT.md). In a nutshell, the code says [Be Excellent to Each Other!](https://www.youtube.com/watch?v=rph_1DODXDU) Please report any suspected to violations to one of the Core Developers.
+As a contributor, you agree to abide by the [Contributor Covenant Code of Conduct](https://github.com/facebookincubator/flowtorch/blob/master/CODE_OF_CONDUCT.md). In a nutshell, the code says [Be Excellent to Each Other!](https://www.youtube.com/watch?v=rph_1DODXDU) Please report any suspected to violations to one of the Core Developers.
 
 :::note
 How can we put our email address behind a Captcha?

--- a/website/docs/dev/contributing.md
+++ b/website/docs/dev/contributing.md
@@ -12,7 +12,7 @@ We are looking for independent collaborators to:
 The core developers are able to help smooth the process of making a contribution.
 
 :::info
-Please contact us in [the forum](https://github.com/stefanwebb/flowtorch/discussions) if you are interested in becoming a contributor and tag your discussion with ":bulb: Ideas" - the process is outlined [here](overview).
+Please contact us in [the forum](https://github.com/facebookincubator/flowtorch/discussions) if you are interested in becoming a contributor and tag your discussion with ":bulb: Ideas" - the process is outlined [here](overview).
 :::
 
 :::note

--- a/website/docs/dev/ops.md
+++ b/website/docs/dev/ops.md
@@ -4,14 +4,14 @@ title: Continuous Integration
 sidebar_label: Continuous Integration
 ---
 
-FlowTorch uses [GitHub Actions](https://docs.github.com/en/actions) to run code quality tests on pushes or pull requests to the `master` branch, a process known as [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration) (CI). The tests are run for Python versions 3.6, 3.7, and 3.8, and must be successful for a PR to be merged into `master`. All workflow runs can be viewed [here](https://github.com/stefanwebb/flowtorch/actions), or else viewed from the link at the bottom of the [PR](https://github.com/stefanwebb/flowtorch/pulls) in question.
+FlowTorch uses [GitHub Actions](https://docs.github.com/en/actions) to run code quality tests on pushes or pull requests to the `master` branch, a process known as [continuous integration](https://en.wikipedia.org/wiki/Continuous_integration) (CI). The tests are run for Python versions 3.6, 3.7, and 3.8, and must be successful for a PR to be merged into `master`. All workflow runs can be viewed [here](https://github.com/facebookincubator/flowtorch/actions), or else viewed from the link at the bottom of the [PR](https://github.com/facebookincubator/flowtorch/pulls) in question.
 
 :::info
 Please do not feel intimidated by the thought of having to make your code pass the CI tests! The core developer team is happy to work closely with contributors to integrate their code and merge PRs.
 :::
 
 ## Workflow Steps
-The definition of the steps performed in the build workflow is found [here](https://github.com/stefanwebb/flowtorch/blob/master/.github/workflows/python-package.yml) and is as follows:
+The definition of the steps performed in the build workflow is found [here](https://github.com/facebookincubator/flowtorch/blob/master/.github/workflows/python-package.yml) and is as follows:
 
 1. The version of Python (3.6, 3.7, or 3.8) is installed along with the developer dependencies of FlowTorch;
 ```bash
@@ -25,7 +25,7 @@ pip install -e .[dev]
 Currently, FlowTorch requires the nightly build of PyTorch since it depends on features of [`torch.distributions.transforms`](https://github.com/pytorch/pytorch/blob/master/torch/distributions/transforms.py) that have not yet been released in a stable version.
 :::
 
-2. The formatting of the Python code in the [library](https://github.com/stefanwebb/flowtorch/tree/master/flowtorch) and [tests](https://github.com/stefanwebb/flowtorch/tree/master/tests) is checked to ensure it follows a standard using [`black`](https://black.readthedocs.io/en/stable/);
+2. The formatting of the Python code in the [library](https://github.com/facebookincubator/flowtorch/tree/master/flowtorch) and [tests](https://github.com/facebookincubator/flowtorch/tree/master/tests) is checked to ensure it follows a standard using [`black`](https://black.readthedocs.io/en/stable/);
 ```bash
 black --check flowtorch tests
 ```
@@ -86,7 +86,7 @@ cd docs
 sphinx-apidoc -o source ../flowtorch/
 ```
 :::note
-Currently, the Sphinx output is not integrated with the [Docusaurus v2 website](https://flowtorch.ai/api). In a future release, we would like to both automate this integration plus the deployment of the website when a PR is merged to `master`. In the meanwhile, core developers can run [this script](https://github.com/stefanwebb/flowtorch/blob/master/deploy-website-windows.bat) (on Windows) - more instructions [here](https://github.com/stefanwebb/flowtorch/tree/master/website).
+Currently, the Sphinx output is not integrated with the [Docusaurus v2 website](https://flowtorch.ai/api). In a future release, we would like to both automate this integration plus the deployment of the website when a PR is merged to `master`. In the meanwhile, core developers can run [this script](https://github.com/facebookincubator/flowtorch/blob/master/deploy-website-windows.bat) (on Windows) - more instructions [here](https://github.com/facebookincubator/flowtorch/tree/master/website).
 :::
 
 ### Formatting and Linting

--- a/website/docs/users/installation.md
+++ b/website/docs/users/installation.md
@@ -8,13 +8,13 @@ sidebar_label: Installation
 
 ## Requirements
 
-Python 3.6 or later is required. Other requirements will be downloaded by `pip` according to [setup.py](https://github.com/stefanwebb/flowtorch/blob/master/setup.py).
+Python 3.6 or later is required. Other requirements will be downloaded by `pip` according to [setup.py](https://github.com/facebookincubator/flowtorch/blob/master/setup.py).
 
 ## Pre-release
 
-As [FlowTorch](https://flowtorch.ai) is currently under rapid development, we recommend installing the [latest commit](https://github.com/stefanwebb/flowtorch/commits/master) from GitHub:
+As [FlowTorch](https://flowtorch.ai) is currently under rapid development, we recommend installing the [latest commit](https://github.com/facebookincubator/flowtorch/commits/master) from GitHub:
 
-    git clone https://github.com/stefanwebb/flowtorch.git
+    git clone https://github.com/facebookincubator/flowtorch.git
     cd flowtorch
     pip install -e .
 
@@ -24,12 +24,12 @@ Updates can then be performed by navigating to the directory where you cloned [F
 
 ## Latest Release
 
-Alternatively, the [latest release](https://github.com/stefanwebb/flowtorch/releases) is installed from [PyPI](https://pypi.org/project/flowtorch/):
+Alternatively, the [latest release](https://github.com/facebookincubator/flowtorch/releases) is installed from [PyPI](https://pypi.org/project/flowtorch/):
 
     pip install flowtorch
 
 ## Developers
 
-[Additional libraries](https://github.com/stefanwebb/flowtorch/blob/master/setup.py#L14) required for development are installed by replacing the above `pip` command with:
+[Additional libraries](https://github.com/facebookincubator/flowtorch/blob/master/setup.py#L14) required for development are installed by replacing the above `pip` command with:
 
     pip install -e .[dev]

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -6,14 +6,14 @@ module.exports = {
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.png',
-  organizationName: 'stefanwebb',
+  organizationName: 'facebookincubator',
   projectName: 'flowtorch',
   baseUrlIssueBanner: true,
   themeConfig: {
     announcementBar: {
       id: 'supportus',
       content:
-        '⭐️ If you like FlowTorch, give it a star on <a target="_blank" rel="noopener noreferrer" href="https://github.com/stefanwebb/flowtorch">GitHub</a>! ⭐️',
+        '⭐️ If you like FlowTorch, give it a star on <a target="_blank" rel="noopener noreferrer" href="https://github.com/facebookincubator/flowtorch">GitHub</a>! ⭐️',
     },
     prism: {
       theme: require("prism-react-renderer/themes/github"),
@@ -45,17 +45,17 @@ module.exports = {
           position: 'left',
         },
         {
-          href: 'https://github.com/stefanwebb/flowtorch/discussions',
+          href: 'https://github.com/facebookincubator/flowtorch/discussions',
           label: 'Discussions',
           position: 'right',
         },
         {
-          href: 'https://github.com/stefanwebb/flowtorch/releases',
+          href: 'https://github.com/facebookincubator/flowtorch/releases',
           label: 'Releases',
           position: 'right',
         },
         {
-          href: 'https://github.com/stefanwebb/flowtorch',
+          href: 'https://github.com/facebookincubator/flowtorch',
           label: 'GitHub',
           position: 'right',
         },
@@ -81,7 +81,7 @@ module.exports = {
             },
             {
               label: 'Roadmap',
-              href: 'https://github.com/stefanwebb/flowtorch/projects',
+              href: 'https://github.com/facebookincubator/flowtorch/projects',
             },
           ],
         },
@@ -90,19 +90,19 @@ module.exports = {
           items: [
             {
               label: 'Raise an issue',
-              href: 'https://github.com/stefanwebb/flowtorch/issues/new/choose',
+              href: 'https://github.com/facebookincubator/flowtorch/issues/new/choose',
             },
             {
               label: 'Ask for help',
-              href: 'https://github.com/stefanwebb/flowtorch/discussions/new',
+              href: 'https://github.com/facebookincubator/flowtorch/discussions/new',
             },
             {
               label: 'Give us feedback',
-              href: 'https://github.com/stefanwebb/flowtorch/discussions/categories/feedback',
+              href: 'https://github.com/facebookincubator/flowtorch/discussions/categories/feedback',
             },
             {
               label: 'Fork the repo',
-              href: 'https://github.com/stefanwebb/flowtorch/fork',
+              href: 'https://github.com/facebookincubator/flowtorch/fork',
             },
           ],
         },
@@ -111,7 +111,7 @@ module.exports = {
           items: [
             {
               label: 'MIT Open Source License',
-              href: 'https://github.com/stefanwebb/flowtorch/blob/master/LICENSE.txt',
+              href: 'https://github.com/facebookincubator/flowtorch/blob/master/LICENSE.txt',
             },
             {
               label: 'Code of Conduct',
@@ -129,7 +129,7 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: 'https://github.com/stefanwebb/flowtorch/edit/master/website/',
+          editUrl: 'https://github.com/facebookincubator/flowtorch/edit/master/website/',
           routeBasePath: '/',
         },
         blog: false,

--- a/website/src/theme/Hero/index.js
+++ b/website/src/theme/Hero/index.js
@@ -14,7 +14,7 @@ function Hero() {
     <header id="hero" className={clsx("hero", styles.banner)}>
       <div className="container">
           <div className="row">
-            
+
           <h1 className="hero__subtitle">
             <img className="hero__img" src="img/logo.svg" />
             Easily <span className="hero__primary">learn</span> and <span className="hero__primary">sample</span> complex <span className="hero__secondary">probability distributions</span> with PyTorch
@@ -43,15 +43,15 @@ function Hero() {
               >
                 Contribute
               </Link>
-              
+
                 <iframe
                   className="hero__github_button"
-                  src="https://ghbtns.com/github-btn.html?user=stefanwebb&amp;repo=flowtorch&amp;type=star&amp;count=true&amp;size=large"
+                  src="https://ghbtns.com/github-btn.html?user=facebookincubator&amp;repo=flowtorch&amp;type=star&amp;count=true&amp;size=large"
                   width={160}
                   height={30}
                   title="GitHub Stars"
                 />
-              
+
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
To make consistent with FB OSS.

### Changes proposed
Points links towards fbincubator repo (previously at stefanwebb)

### Test Plan
`gh-pages` deploy

### Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTING](https://github.com/facebookincubator/flowtorch/blob/master/CONTRIBUTING.md)** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.
