### PR TITLE
Fix flowtorch + bm MFVI test

### DIFF
--- a/flowtorch/bijectors/base.py
+++ b/flowtorch/bijectors/base.py
@@ -74,7 +74,7 @@ class Bijector(object):
         self,
         x: torch.Tensor,
         params: Optional["flowtorch.params.ParamsModule"],
-        context: Optional[torch.Tensor],
+        context: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """
         Abstract method to compute forward transformation.
@@ -119,7 +119,7 @@ class Bijector(object):
         x: torch.Tensor,
         y: torch.Tensor,
         params: Optional["flowtorch.params.ParamsModule"],
-        context: Optional[torch.Tensor],
+        context: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """
         Computes the log det jacobian `log |dy/dx|` given input and output.
@@ -211,7 +211,7 @@ class _InverseBijector(Bijector):
         x: torch.Tensor,
         y: torch.Tensor,
         params: Optional["flowtorch.params.ParamsModule"],
-        context: Optional[torch.Tensor],
+        context: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         return -self._inv.log_abs_det_jacobian(y, x, params, context)
 

--- a/flowtorch/docs.py
+++ b/flowtorch/docs.py
@@ -39,22 +39,20 @@ def _documentable_modules() -> Dict[Any, Sequence[Any]]:
     def dfs(dict):
         for key, val in dict.items():
             module = importlib.import_module(key)
-            entities = list(
-                [
-                    (n, getattr(module, n))
-                    for n in sorted(
-                        [
-                            n
-                            for n in dir(module)
-                            if ispublic(n)
-                            and (
-                                isclass(getattr(module, n))
-                                or isfunction(getattr(module, n))
-                            )
-                        ]
-                    )
-                ]
-            )
+            entities = [
+                (n, getattr(module, n))
+                for n in sorted(
+                    [
+                        n
+                        for n in dir(module)
+                        if ispublic(n)
+                        and (
+                            isclass(getattr(module, n))
+                            or isfunction(getattr(module, n))
+                        )
+                    ]
+                )
+            ]
             results[module] = entities
 
             dfs(val)
@@ -80,7 +78,7 @@ def _documentable_entities():
             qualified_name = f"{module.__name__}.{name}"
             name_entity_mapping[qualified_name] = entity
 
-    sorted_entity_names = list(sorted(name_entity_mapping.keys()))
+    sorted_entity_names = sorted(name_entity_mapping.keys())
     return sorted_entity_names, name_entity_mapping
 
 

--- a/flowtorch/ops/__init__.py
+++ b/flowtorch/ops/__init__.py
@@ -5,9 +5,6 @@ import torch
 eps = 1e-8
 
 
-eps = 1e-8
-
-
 def clamp_preserve_gradients(x: torch.Tensor, min: float, max: float) -> torch.Tensor:
     # This helper function clamps gradients but still passes through the
     # gradient in clamped regions

--- a/tests/test_bijector.py
+++ b/tests/test_bijector.py
@@ -84,7 +84,7 @@ class TestBijectors:
         # Have to permute elements for MADE
         count_vars = len(idxs[0])
         if hasattr(params, "permutation"):
-            inv_permutation = np.zeros(count_vars, dtype=np.int)
+            inv_permutation = np.zeros(count_vars, dtype=int)
             inv_permutation[params.permutation] = np.arange(count_vars)
 
         # TODO: Vectorize numerical calculation of Jacobian with PyTorch

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -61,12 +61,12 @@ def test_neals_funnel_vi():
     tdist, params = flow(
         dist.Independent(dist.Normal(torch.zeros(2), torch.ones(2)), 1)
     )
-    opt = torch.optim.Adam(params.parameters(), lr=1e-3)
-    num_elbo_mc_samples = 10
+    opt = torch.optim.Adam(params.parameters(), lr=2e-3)
+    num_elbo_mc_samples = 200
     for _ in range(100):
         z0 = tdist.base_dist.rsample(sample_shape=(num_elbo_mc_samples,))
-        zk = flow._forward(z0, params, context=torch.empty(0))
-        ldj = flow._log_abs_det_jacobian(z0, zk, params, context=torch.empty(0))
+        zk = flow._forward(z0, params)
+        ldj = flow._log_abs_det_jacobian(z0, zk, params)
 
         neg_elbo = -nf.log_prob(zk).sum()
         neg_elbo += tdist.base_dist.log_prob(z0).sum() - ldj.sum()


### PR DESCRIPTION
Summary: Change learning rates to fix a regression in beanmachine mean-field variational inference introduced from flowtorch switching activation functions PReLU -> ReLU

Differential Revision: D29563904

