### PR TITLE
Bijectors are deep copied when instantiated

### DIFF
--- a/flowtorch/bijectors/__init__.py
+++ b/flowtorch/bijectors/__init__.py
@@ -71,7 +71,8 @@ for bij_name, cls in standard_bijectors:
     event_dim = max(bij.domain.event_dim, 1)
     event_shape = event_dim * [4]
     base_dist = dist.Normal(torch.zeros(event_shape), torch.ones(event_shape))
-    _ = bij(base_dist)
+    flow = bij(base_dist)
+    bij = flow.bijector
 
     try:
         y = torch.randn(*bij.forward_shape(event_shape))

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -27,6 +27,7 @@ def test_compose():
     event_shape = (5,)
     base_dist = dist.Normal(loc=torch.zeros(event_shape), scale=torch.ones(event_shape))
     new_dist = flow(base_dist)
+    flow = new_dist.bijector
 
     optimizer = torch.optim.Adam(flow.params.parameters())
     assert optimizer.param_groups[0]["params"][0].grad is None

--- a/tests/test_conditional.py
+++ b/tests/test_conditional.py
@@ -22,6 +22,7 @@ def test_conditional_2gmm():
 
     base_dist = dist.Normal(torch.zeros(2), torch.ones(2))
     new_cond_dist = flow(base_dist)
+    flow = new_cond_dist.bijector
 
     target_dist_0 = dist.Independent(
         dist.Normal(torch.zeros(2) + 5, torch.ones(2) * 0.5), 1

--- a/tests/test_distribution.py
+++ b/tests/test_distribution.py
@@ -73,6 +73,7 @@ def test_neals_funnel_vi():
         flowtorch.params.DenseAutoregressive()
     )
     tdist = flow(dist.Independent(dist.Normal(torch.zeros(2), torch.ones(2)), 1))
+    flow = tdist.bijector
     opt = torch.optim.Adam(flow.params.parameters(), lr=2e-3)
     num_elbo_mc_samples = 200
     for _ in range(100):
@@ -109,6 +110,7 @@ def test_conditional_2gmm():
 
     base_dist = dist.Normal(torch.zeros(2), torch.ones(2))
     new_cond_dist = flow(base_dist)
+    flow = new_cond_dist.bijector
 
     target_dist_0 = dist.Independent(
         dist.Normal(torch.zeros(2) + 5, torch.ones(2) * 0.5), 1


### PR DESCRIPTION
### Motivation
Currently, when you call a `Bijector` object the first time it's `.params` attribute is filled with any hypernets etc. But there is nothing stopping a user from calling the `Bijector` a second time, which may return an inconsistent `TransformedDistribution`

### Changes proposed
I propose doing a deep copy of the `Bijector` and passing the copy to `TransformedDistribution` each time the "bijector plan" is instantiated. This way `Bijector` will remain a plan, and the concrete version will live inside `TransformedDistribution`
