### PR TITLE
Fixed bijector type

### DIFF
--- a/flowtorch/bijectors/affine_fixed.py
+++ b/flowtorch/bijectors/affine_fixed.py
@@ -6,10 +6,10 @@ from typing import Optional
 
 import flowtorch
 import torch
-from flowtorch.bijectors.base import Bijector
+from flowtorch.bijectors.fixed import Fixed
 
 
-class AffineFixed(Bijector):
+class AffineFixed(Fixed):
     r"""
     Elementwise bijector via the affine mapping :math:`\mathbf{y} = \mu +
     \sigma \otimes \mathbf{x}` where $\mu$ and $\sigma$ are fixed rather than

--- a/flowtorch/bijectors/elu.py
+++ b/flowtorch/bijectors/elu.py
@@ -6,11 +6,11 @@ from typing import Optional
 import torch
 import torch.distributions.constraints as constraints
 import torch.nn.functional as F
-from flowtorch.bijectors.base import Bijector
+from flowtorch.bijectors.fixed import Fixed
 from flowtorch.ops import eps
 
 
-class ELU(Bijector):
+class ELU(Fixed):
     codomain = constraints.greater_than(-1.0)
 
     # TODO: Setting the alpha value of ELU as __init__ argument

--- a/flowtorch/bijectors/exp.py
+++ b/flowtorch/bijectors/exp.py
@@ -5,10 +5,10 @@ from typing import Optional
 
 import torch
 import torch.distributions.constraints as constraints
-from flowtorch.bijectors.base import Bijector
+from flowtorch.bijectors.fixed import Fixed
 
 
-class Exp(Bijector):
+class Exp(Fixed):
     r"""
     Elementwise bijector via the mapping :math:`y = \exp(x)`.
     """

--- a/flowtorch/bijectors/fixed.py
+++ b/flowtorch/bijectors/fixed.py
@@ -15,37 +15,10 @@ class Fixed(Bijector):
         params: Optional[flowtorch.Lazy] = None,
         context_size: int = 0,
     ) -> None:
+        # TODO: In the future, make Fixed actually mean that there is no autograd
+        # through params
         super().__init__(shape, params, context_size)
         assert params is None
-
-    def forward(
-        self,
-        x: torch.Tensor,
-        context: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        assert context is None or context.shape == (self._context_size,)
-        return self._forward(x, context)
-
-    def inverse(
-        self,
-        y: torch.Tensor,
-        context: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        assert context is None or context.shape == (self._context_size,)
-        return self._inverse(y, context)
-
-    def log_abs_det_jacobian(
-        self,
-        x: torch.Tensor,
-        y: torch.Tensor,
-        context: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        """
-        Computes the log det jacobian `log |dy/dx|` given input and output.
-        By default, assumes a volume preserving bijection.
-        """
-        assert context is None or context.shape == (self._context_size,)
-        return self._log_abs_det_jacobian(x, y, context)
 
     def param_shapes(self, shape: torch.Size) -> Sequence[torch.Size]:
         """
@@ -53,4 +26,6 @@ class Fixed(Bijector):
         of that distribution under this bijector. By default, no parameters are
         set.
         """
+        # TODO: In the future, make Fixed actually mean that there is no autograd
+        # through params
         return []

--- a/flowtorch/bijectors/leaky_relu.py
+++ b/flowtorch/bijectors/leaky_relu.py
@@ -6,10 +6,10 @@ from typing import Optional
 
 import torch
 import torch.nn.functional as F
-from flowtorch.bijectors.base import Bijector
+from flowtorch.bijectors.fixed import Fixed
 
 
-class LeakyReLU(Bijector):
+class LeakyReLU(Fixed):
     # TODO: Setting the slope of Leaky ReLU as __init__ argument
 
     def _forward(

--- a/flowtorch/bijectors/power.py
+++ b/flowtorch/bijectors/power.py
@@ -6,10 +6,10 @@ from typing import Optional
 import flowtorch
 import torch
 import torch.distributions.constraints as constraints
-from flowtorch.bijectors.base import Bijector
+from flowtorch.bijectors.fixed import Fixed
 
 
-class Power(Bijector):
+class Power(Fixed):
     r"""
     Elementwise bijector via the mapping :math:`y = x^{\text{exponent}}`.
     """

--- a/flowtorch/bijectors/sigmoid.py
+++ b/flowtorch/bijectors/sigmoid.py
@@ -6,11 +6,11 @@ from typing import Optional
 import torch
 import torch.distributions.constraints as constraints
 import torch.nn.functional as F
-from flowtorch.bijectors.base import Bijector
+from flowtorch.bijectors.fixed import Fixed
 from flowtorch.ops import clipped_sigmoid
 
 
-class Sigmoid(Bijector):
+class Sigmoid(Fixed):
     codomain = constraints.unit_interval
 
     def _forward(

--- a/flowtorch/bijectors/softplus.py
+++ b/flowtorch/bijectors/softplus.py
@@ -7,10 +7,10 @@ import flowtorch.ops
 import torch
 import torch.distributions.constraints as constraints
 import torch.nn.functional as F
-from flowtorch.bijectors.base import Bijector
+from flowtorch.bijectors.fixed import Fixed
 
 
-class Softplus(Bijector):
+class Softplus(Fixed):
     r"""
     Elementwise bijector via the mapping :math:`\text{Softplus}(x) = \log(1 + \exp(x))`.
     """

--- a/flowtorch/bijectors/tanh.py
+++ b/flowtorch/bijectors/tanh.py
@@ -7,10 +7,10 @@ from typing import Optional
 import torch
 import torch.distributions.constraints as constraints
 import torch.nn.functional as F
-from flowtorch.bijectors.base import Bijector
+from flowtorch.bijectors.fixed import Fixed
 
 
-class Tanh(Bijector):
+class Tanh(Fixed):
     r"""
     Transform via the mapping :math:`y = \tanh(x)`.
     """


### PR DESCRIPTION
### Motivation
We would like to enforce type checking between `Bijector`s and the Parameters that they are used with, see #6 and #22. A solution we will try that is implemented here is to make a number of "types" for `Bijector`s such as `Fixed`, `Elementwise`, `Autoregressive`, `Coupling`, and `Dense`.

### Changes proposed
This PR implements a class `Fixed` that enforces that a `Bijector`'s parameters should be `None`. In the future, we may wish to change the semantics of `Fixed` so that it means that params is `None` or params does not have any autodiff gradients (i.e. it is not a strict subclass of `Elementwise`).

### Test Plan
Tests to follow in a future PR
