### PR TITLE
Added CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+0.3 (September 15, 2021)
+
+* Deferred initialization of `Bijector`s and `Parameters` is expressed using the `flowtorch.LazyMeta` metaclass
+* AffineAutoregressive can operate on inputs with arbitrary `event_shape`s
+* A few cosmetic changes like changing `flowtorch.params.*` to `flowtorch.parameters.*`
+* Temporarily removed conditional bijectors/transformed distributions and inverting bijectors


### PR DESCRIPTION
Having a `CHANGELOG.md` is recommended before open-sourcing a project, hence I have created one here.

Currently it contains the most recent pre-release 0.3 changes. I anticipate that before the open source release we will begin the change log from the first non-pre-release version.