### PR TITLE
Removed CI testing for Python 3.6 and added 3.9

### DIFF
--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.7', '3.8', '3.9']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
### Motivation
GitHub workflows with using `macos-latest` now install MacOS 11 and have removed supported for Python 3.6, which is end-of-life (see [here](https://github.com/actions/virtual-environments/issues/4060)).

### Changes proposed
Removing Python 3.6 from CI OS/Python version testing matrix and add 3.9