### PR TITLE
Fix PyPI publish workflow

### DIFF
--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Build source distribution
       run: python setup.py sdist bdist_wheel
     - name: Upload to PyPI
-      uses: pypa/gh-action-pypi-publish@main
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         verbose: true
         user: __token__


### PR DESCRIPTION
Summary: Just noticed that we're referring a no-existing "main" version of `pypa/gh-action-pypi-publish`. This is probably an artifact when we renamed `master` branch to `main` on our own repo. Since [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish/tree/master) doesn't have a main branch, this will likely error out the next time we run the PyPI publish workflow.

Differential Revision: D32006423

