### PR TITLE
Adding Google Analytics to website for Automated Repo Checkup

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -22,6 +22,10 @@ module.exports = {
   ],
   baseUrlIssueBanner: true,
   themeConfig: {
+    gtag: {
+      trackingID: 'G-X921WXL42L',
+      anonymizeIP: true,
+    },
     announcementBar: {
       id: 'supportus',
       content:


### PR DESCRIPTION
Summary: Enabled Google Analytics for the Docsaurus v2 website to get automated repo checkup to pass

Differential Revision: D32608371

