### PR TITLE
First interesting tutorial: Bayesian Inference with Transport score climbing

### DIFF
--- a/flowtorch/bijectors/__init__.py
+++ b/flowtorch/bijectors/__init__.py
@@ -14,6 +14,7 @@ from flowtorch.bijectors.affine import Affine
 from flowtorch.bijectors.affine_autoregressive import AffineAutoregressive
 from flowtorch.bijectors.affine_fixed import AffineFixed
 from flowtorch.bijectors.autoregressive import Autoregressive
+from flowtorch.bijectors.banana import Banana
 from flowtorch.bijectors.base import Bijector
 from flowtorch.bijectors.compose import Compose
 from flowtorch.bijectors.elementwise import Elementwise
@@ -34,6 +35,7 @@ standard_bijectors = [
     ("Affine", Affine),
     ("AffineAutoregressive", AffineAutoregressive),
     ("AffineFixed", AffineFixed),
+    ("Banana", Banana),
     ("ELU", ELU),
     ("Exp", Exp),
     ("LeakyReLU", LeakyReLU),
@@ -76,7 +78,10 @@ for bij_name, cls in standard_bijectors:
     # TODO: Use factored out version of the following
     # Define plan for flow
     event_dim = max(cls.domain.event_dim, 1)  # type: ignore
-    event_shape = event_dim * [4]
+
+    # TODO: Sometimes a bijector operates on specific event shapes.
+    # How to generalize this?
+    event_shape = event_dim * [2]
     # base_dist = dist.Normal(torch.zeros(event_shape), torch.ones(event_shape))
     bij = cls(shape=torch.Size(event_shape))
 

--- a/flowtorch/bijectors/__init__.py
+++ b/flowtorch/bijectors/__init__.py
@@ -78,10 +78,7 @@ for bij_name, cls in standard_bijectors:
     # TODO: Use factored out version of the following
     # Define plan for flow
     event_dim = max(cls.domain.event_dim, 1)  # type: ignore
-
-    # TODO: Sometimes a bijector operates on specific event shapes.
-    # How to generalize this?
-    event_shape = event_dim * [2]
+    event_shape = event_dim * [4]
     # base_dist = dist.Normal(torch.zeros(event_shape), torch.ones(event_shape))
     bij = cls(shape=torch.Size(event_shape))
 

--- a/flowtorch/bijectors/banana.py
+++ b/flowtorch/bijectors/banana.py
@@ -1,0 +1,51 @@
+# Copyright (c) Meta Platforms, Inc
+import math
+from typing import Any, Optional, Sequence, Tuple
+
+import torch
+import torch.distributions.constraints as constraints
+
+import flowtorch
+from flowtorch.bijectors.fixed import Fixed
+
+
+class Banana(Fixed):
+    domain = constraints.real_vector
+    codomain = constraints.real_vector
+    b_coef = 0.02
+    
+    def __init__(
+        self,
+        params_fn: Optional[flowtorch.Lazy] = None,
+        *,
+        shape: torch.Size,
+        context_shape: Optional[torch.Size] = None
+    ) -> None:
+        super().__init__(params_fn, shape=shape, context_shape=context_shape)
+
+        # Check that we're operating on a bivariate base distribution
+        if len(shape) != 1 or shape[-1] != 2:
+            raise ValueError("Base distribution to Banana is not bivariate.")       
+
+    def _forward(
+        self, x: torch.Tensor, params: Optional[Sequence[torch.Tensor]]
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        y0 = 10.0 * x[..., 0]
+        y1 = x[..., 1] + 100.0 * self.b_coef * torch.square(x[..., 0]) - 100.0 * 0.02
+        y = torch.stack([y0, y1], dim=-1)
+        ladj = self._log_abs_det_jacobian(x, y, params)
+        return y, ladj
+
+    def _inverse(
+        self, y: torch.Tensor, params: Optional[Sequence[torch.Tensor]]
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        x0 = 0.1 * y[..., 0]
+        x1 = y[..., 1] - self.b_coef * torch.square(y[..., 0]) + 100.0 * 0.02
+        x = torch.stack([x0, x1], dim=-1)
+        ladj = self._log_abs_det_jacobian(x, y, params)
+        return y, ladj
+
+    def _log_abs_det_jacobian(
+        self, x: torch.Tensor, y: torch.Tensor, params: Optional[Sequence[torch.Tensor]]
+    ) -> torch.Tensor:
+        return math.log(10.0) * torch.ones(size=x.shape[:-1])

--- a/flowtorch/bijectors/banana.py
+++ b/flowtorch/bijectors/banana.py
@@ -1,11 +1,10 @@
 # Copyright (c) Meta Platforms, Inc
 import math
-from typing import Any, Optional, Sequence, Tuple
-
-import torch
-import torch.distributions.constraints as constraints
+from typing import Optional, Sequence, Tuple
 
 import flowtorch
+import torch
+import torch.distributions.constraints as constraints
 from flowtorch.bijectors.fixed import Fixed
 
 
@@ -13,7 +12,7 @@ class Banana(Fixed):
     domain = constraints.real_vector
     codomain = constraints.real_vector
     b_coef = 0.02
-    
+
     def __init__(
         self,
         params_fn: Optional[flowtorch.Lazy] = None,
@@ -25,7 +24,7 @@ class Banana(Fixed):
 
         # Check that we're operating on a bivariate base distribution
         if len(shape) != 1 or shape[-1] != 2:
-            raise ValueError("Base distribution to Banana is not bivariate.")       
+            raise ValueError("Base distribution to Banana is not bivariate.")
 
     def _forward(
         self, x: torch.Tensor, params: Optional[Sequence[torch.Tensor]]

--- a/flowtorch/distributions/__init__.py
+++ b/flowtorch/distributions/__init__.py
@@ -6,7 +6,8 @@ Do not modify or delete!
 
 """
 
+from flowtorch.distributions.banana import Banana
 from flowtorch.distributions.flow import Flow
 from flowtorch.distributions.neals_funnel import NealsFunnel
 
-__all__ = ["Flow", "NealsFunnel"]
+__all__ = ["Banana", "Flow", "NealsFunnel"]

--- a/flowtorch/distributions/banana.py
+++ b/flowtorch/distributions/banana.py
@@ -1,0 +1,60 @@
+# Copyright (c) Meta Platforms, Inc
+from typing import Any, Dict, Optional, Union
+
+import torch
+import torch.distributions as dist
+from torch.distributions import constraints
+from torch.distributions.utils import _standard_normal
+
+
+class Banana(dist.Distribution):
+    """
+    Banana shaped distribution.
+
+    Let $$(z_1, z_2)\\sim\\mathcal{N}(0, (100, 0; 0, 1)) $$. Then the "banana
+    distribution" is defined as, $$\\theta_1=z_1$$,
+    $$\\theta_2=z_2+b\\cdot z^2_1-100b$$ for $$b=0.02$$.
+
+    """
+
+    support = constraints.real
+    arg_constraints: Dict[str, dist.constraints.Constraint] = {}
+
+    def __init__(self, validate_args: Any = None) -> None:
+        d = 2
+        batch_shape, event_shape = torch.Size([]), (d,)
+        super(Banana, self).__init__(
+            batch_shape, event_shape, validate_args=validate_args
+        )
+
+    def rsample(
+        self,
+        sample_shape: Union[torch.Tensor, torch.Size] = None,
+        context: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        if not sample_shape:
+            sample_shape = torch.Size()
+        eps = _standard_normal(
+            # TODO: Should this really be [0]?
+            (sample_shape[0], 2),
+            dtype=torch.float,
+            device=torch.device("cpu"),
+        )
+        z = torch.zeros(eps.shape)
+        z[..., 0] = 10.0 * eps[..., 0]
+        z[..., 1] = eps[..., 1] + 0.02 * torch.square(eps[..., 0]) - 100.0 * 0.02
+        return z
+
+    def log_prob(
+        self, value: torch.Tensor, context: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        if self._validate_args:
+            self._validate_sample(value)
+        z = torch.zeros(value.shape)
+        z[..., 0] = value[..., 0]
+        z[..., 1] = value[..., 1] - 0.02 * torch.square(value[..., 0]) + 100.0 * 0.02
+
+        # TODO: Check shape of the following
+        log_prob = dist.Normal(0, 1.0).log_prob(z).sum(-1)
+
+        return log_prob

--- a/flowtorch/distributions/banana.py
+++ b/flowtorch/distributions/banana.py
@@ -1,5 +1,4 @@
 # Copyright (c) Meta Platforms, Inc
-import math
 from typing import Any, Dict, Optional, Union
 
 import torch
@@ -46,7 +45,9 @@ class Banana(dist.Distribution):
         )
         z = torch.zeros(eps.shape)
         z[..., 0] = 10.0 * eps[..., 0]
-        z[..., 1] = eps[..., 1] + 100.0 * 0.02 * torch.square(eps[..., 0]) - 100.0 * 0.02
+        z[..., 1] = (
+            eps[..., 1] + 100.0 * 0.02 * torch.square(eps[..., 0]) - 100.0 * 0.02
+        )
         return z
 
     def log_prob(
@@ -60,5 +61,5 @@ class Banana(dist.Distribution):
         # Since volume-preserving, no need to add log(det(|J|)) term
         log_prob = dist.Normal(0, 1.0).log_prob(x)
         log_prob += dist.Normal(0, 1.0).log_prob(y)
-        #log_prob += math.log(10)
+        # log_prob += math.log(10)
         return log_prob

--- a/flowtorch/distributions/banana.py
+++ b/flowtorch/distributions/banana.py
@@ -15,6 +15,9 @@ class Banana(dist.Distribution):
     distribution" is defined as, $$\\theta_1=z_1$$,
     $$\\theta_2=z_2+b\\cdot z^2_1-100b$$ for $$b=0.02$$.
 
+    It can be easily shown that this is a volume-preserving transformation,
+    that is, $$\\log(|\\det J|)=0$$.
+
     """
 
     support = constraints.real
@@ -42,7 +45,7 @@ class Banana(dist.Distribution):
         )
         z = torch.zeros(eps.shape)
         z[..., 0] = 10.0 * eps[..., 0]
-        z[..., 1] = eps[..., 1] + 0.02 * torch.square(eps[..., 0]) - 100.0 * 0.02
+        z[..., 1] = eps[..., 1] + 0.02 * torch.square(z[..., 0]) - 100.0 * 0.02
         return z
 
     def log_prob(
@@ -54,7 +57,6 @@ class Banana(dist.Distribution):
         z[..., 0] = value[..., 0]
         z[..., 1] = value[..., 1] - 0.02 * torch.square(value[..., 0]) + 100.0 * 0.02
 
-        # TODO: Check shape of the following
+        # Since volume-preserving, no need to add log(det(|J|)) term
         log_prob = dist.Normal(0, 1.0).log_prob(z).sum(-1)
-
         return log_prob

--- a/scripts/generate_imports.py
+++ b/scripts/generate_imports.py
@@ -54,7 +54,10 @@ for bij_name, cls in standard_bijectors:
     # TODO: Use factored out version of the following
     # Define plan for flow
     event_dim = max(cls.domain.event_dim, 1)  # type: ignore
-    event_shape = event_dim * [4]
+    
+    # TODO: Sometimes a bijector operates on specific event shapes.
+    # How to generalize this?
+    event_shape = event_dim * [2]
     # base_dist = dist.Normal(torch.zeros(event_shape), torch.ones(event_shape))
     bij = cls(shape=torch.Size(event_shape))
 

--- a/scripts/generate_imports.py
+++ b/scripts/generate_imports.py
@@ -54,7 +54,7 @@ for bij_name, cls in standard_bijectors:
     # TODO: Use factored out version of the following
     # Define plan for flow
     event_dim = max(cls.domain.event_dim, 1)  # type: ignore
-    
+
     # TODO: Sometimes a bijector operates on specific event shapes.
     # How to generalize this?
     event_shape = event_dim * [2]

--- a/tests/test_bijector.py
+++ b/tests/test_bijector.py
@@ -19,7 +19,7 @@ def test_bijector_constructor():
 def flow(request):
     bij = request.param
     event_dim = max(bij.domain.event_dim, 1)
-    event_shape = event_dim * [3]
+    event_shape = event_dim * [2]
     base_dist = dist.Independent(
         dist.Normal(torch.zeros(event_shape), torch.ones(event_shape)), event_dim
     )

--- a/tutorials/transport_score_climbing.ipynb
+++ b/tutorials/transport_score_climbing.ipynb
@@ -7,7 +7,7 @@
     "# Transport Score Climbing\n",
     "This tutorial examines a recently developed method for Bayesian inference called Transport Score Climbing (TSC) ([Zhang et al., 2022](https://arxiv.org/abs/2202.01841)). We explain how the method works and how to implement it using FlowTorch. Then, we demonstrate TSC on a simple toy example, replicating Figure 3 from [the paper](https://arxiv.org/pdf/2202.01841.pdf), and comparing to modern black-box variational inference.\n",
     "\n",
-    "[High level explanation of TSC!]\n",
+    "At a high-level, TSC works by combining an MCMC kernel with a normalizing flow to learn an approximation to the posterior. The normalizing flow learns how to Gaussianize the posterior distribution, and the MCMC kernel takes steps in the simpler Gausian space. The two are combined to draw approximate samples from the posterior, estimate gradients through forward KL-divergence, and train the normalizing flow.\n",
     "\n",
     "We assume the reader is familiar with *Bayesian statistics*, *variational inference (VI)*, and *Hamiltonian Monte Carlo (HMC)*."
    ]
@@ -17,6 +17,7 @@
    "metadata": {},
    "source": [
     "## Background\n",
+    "### Introduction\n",
     "The setting is that we have a Bayesian model, $p_\\phi(x, z)$, and wish to perform approximate Bayesian inference over it, that is, either calculate an approximation to the posterior, $p_\\phi(z\\mid x)$, or some expectation with respect to it. In our notation, $x$ denotes observed variables, $z$ denotes latent variables, and the model is represented as the product of a prior and likelihood,\n",
     "$$\n",
     "p_\\phi(x, z) = p_\\phi(z)p_\\phi(x\\mid z).\n",
@@ -28,7 +29,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Standard Variational Inference\n",
+    "### Standard Variational Inference\n",
     "Let us briefly review how modern black-box VI works, which we will refer to from here on as *standard VI*. The idea behind VI in the broader sense is to specify a family of approximations to the posterior,\n",
     "$$\\{q_\\psi(z\\mid x)\\mid\\psi\\in\\Psi\\}$$\n",
     "and learn a member from this family, $q_{\\psi*}$, that is \"closest\" to the posterior in some sense. Standard VI defines closeness as the reverse KL-divergence,\n",
@@ -44,7 +45,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Transport Score Climbing\n",
+    "### Transport Score Climbing\n",
     "[Zhang et al., 2022](https://arxiv.org/abs/2202.01841) pose the question: suppose instead we wish to optimize the *forward* KI-divergence,\n",
     "$$\n",
     "\\textnormal{KL}\\{p_\\phi(z\\mid x)\\,||\\,q_\\psi(z\\mid x)\\} \\triangleq \\mathbb{E}_{p_\\phi}\\left[\\ln\\frac{p_\\phi(z\\mid x)}{q_\\psi(z\\mid x)}\\right],\n",
@@ -53,22 +54,83 @@
     "\n",
     "There are several reasons why we might want to optimize the *forward* KL-divergence rather than the *reverse* one. For instance, optimizing the reverse KL-divergence is known to commonly exhibit \"mode-seeking behaviour\" that fits the solution to a single mode and underestimate posterior uncertainty, especially when the variational family is unimodal. Whereas, the forward KL-divergence commonly exhibits \"mode-spreading behaviour\" that fits the solution across modes and give a more realistic estimate of posterior uncertainty.\n",
     "\n",
-    "The idea behind TSC is to approximate the expectation over the integral with samples that are drawn from an MCMC kernel having the posterior as its stationary distribution. Let us elaborate.\n",
+    "TSC combines MCMC methods with normalizing flows. We will represent a normalizing flow for the posterior with \n",
+    "$$\n",
+    "z\\mid x = f_\\psi(\\epsilon; x) \\\\\n",
+    "z\\mid x \\sim q_\\psi(\\cdot\\mid x)\n",
+    "$$\n",
+    "where $\\epsilon$ is the Gausian noise underlying the flow, $f_\\psi$ is the flow's bijection, and $q_\\psi$ is the corresponding density function. We then define an MCMC kernel on the Gaussianized space,\n",
+    "$$\n",
+    "\\epsilon^{t+1} \\sim H\\left[\\,\\cdot\\,;\\,\\epsilon^{t}=f^{-1}_\\psi(z^{t})\\right],\\\\\n",
+    "z^{t+1} = f_\\psi(\\epsilon^{t+1}).\n",
+    "$$\n",
+    "In our case, $H$, represents several steps of HMC with an adaptive stepsize. We see that MCMC is performed on the \"warped space\" defined by applying the inverse operation of the normalizing flow, applying the kernel on this space, then mapping back to the original space of the posterior with the forward operation of the flow. We expect this space to have a simpler Gaussian geometry as the flow approximation improves.\n",
     "\n",
+    "Now, the key idea behind TSC is to approximate the expectation over the posterior in the objective with samples from this MCMC chain, and use these samples to take an approximate gradient through the objective with respect to $\\psi$ and optionally, $\\phi$. *Importantly, we do not pass gradients through the MCMC samples*.\n",
     "\n",
-    "\n",
-    "It turns out that one can prove this algorithm minimizes the forward KL-divergence."
+    "As the normalizing flow approximation improves, the samples from the MCMC chain operate on easier Gaussianized geometry, and applying the MCMC kernel results in the normalizing flow being trained on samples that are closer to those from the posterior. In this way, the MCMC kernel and normalizing flow bootstrap each other's learning. It turns out that one can prove that for this algorithm $\\psi$ and $\\phi$ converge to local optima of the forward KL-divergence and marginal likelihood, respectively."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "### Generalization\n",
+    "In this tutorial, we have motivated TSC by the problem of Bayesian inference. However we note that, similar to standard VI, TSC is a general method for finding the closest member to a (possibly moving) target distribution given a family of distributions. That is, it allows us to learn a distribution in a family, $\\{q_\\psi(w)\\}$ that is close to another distribution, $p_\\phi(w)$, while optionally simultaneously learning $p_\\phi(w)$. Importantly, *$p_\\phi$ does not have to be the posterior of a Bayesian model*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Implementation\n",
+    "It is easy to implement TSC with FlowTorch! In this section, we replicate an experiment on a banana-shaped toy distribution from the paper."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we import the relevant libraries,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from flowtorch.distributions import Banana"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": []
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "4a889874aef137a58c8f92e3ed6912ec441c66e3cc8f3752c91ed486cb306b1b"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.8.5 64-bit ('base': conda)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
   },
   "orig_nbformat": 4
  },

--- a/tutorials/transport_score_climbing.ipynb
+++ b/tutorials/transport_score_climbing.ipynb
@@ -5,7 +5,59 @@
    "metadata": {},
    "source": [
     "# Transport Score Climbing\n",
-    "This tutorial demonstrates a recently developed method for Bayesian inference called Transport Score Climbing ([Zhang et al., 2022](https://arxiv.org/abs/2202.01841)). We explain how the method works, how to implement it using FlowTorch, and demonstrate a simple toy example, replicating Figure 3 from [the paper](https://arxiv.org/pdf/2202.01841.pdf), and comparing to standard variational inference."
+    "This tutorial examines a recently developed method for Bayesian inference called Transport Score Climbing (TSC) ([Zhang et al., 2022](https://arxiv.org/abs/2202.01841)). We explain how the method works and how to implement it using FlowTorch. Then, we demonstrate TSC on a simple toy example, replicating Figure 3 from [the paper](https://arxiv.org/pdf/2202.01841.pdf), and comparing to modern black-box variational inference.\n",
+    "\n",
+    "[High level explanation of TSC!]\n",
+    "\n",
+    "We assume the reader is familiar with *Bayesian statistics*, *variational inference (VI)*, and *Hamiltonian Monte Carlo (HMC)*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Background\n",
+    "The setting is that we have a Bayesian model, $p_\\phi(x, z)$, and wish to perform approximate Bayesian inference over it, that is, either calculate an approximation to the posterior, $p_\\phi(z\\mid x)$, or some expectation with respect to it. In our notation, $x$ denotes observed variables, $z$ denotes latent variables, and the model is represented as the product of a prior and likelihood,\n",
+    "$$\n",
+    "p_\\phi(x, z) = p_\\phi(z)p_\\phi(x\\mid z).\n",
+    "$$\n",
+    "Optional learnable parameters are denoted by $\\phi$; they are often fixed, especially in more traditional Bayesian models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Standard Variational Inference\n",
+    "Let us briefly review how modern black-box VI works, which we will refer to from here on as *standard VI*. The idea behind VI in the broader sense is to specify a family of approximations to the posterior,\n",
+    "$$\\{q_\\psi(z\\mid x)\\mid\\psi\\in\\Psi\\}$$\n",
+    "and learn a member from this family, $q_{\\psi*}$, that is \"closest\" to the posterior in some sense. Standard VI defines closeness as the reverse KL-divergence,\n",
+    "$$\n",
+    "\\textnormal{KL}\\{q_\\psi(z\\mid x)\\,||\\,p_\\phi(z\\mid x)\\} \\triangleq \\mathbb{E}_{q_\\psi}\\left[\\ln\\frac{q_\\psi(z\\mid x)}{p_\\phi(z\\mid x)}\\right],\n",
+    "$$\n",
+    "and minimizes a *lower-bound* on this quantity with respect to $(\\psi, \\phi)$ via stochastic gradient descent. In some settings, the data, $x$, is fixed, and in other cases we taken an additional expectation over $X\\sim f(\\cdot)$ and learn to amortise the cost of inference across related observations from the same distribution, $f(\\cdot)$.\n",
+    "\n",
+    "The main benefit of the formulation of standard VI is computational convenience - to perform approximate inference we only have to be able to draw samples from $q_\\psi$, score $q_\\psi$ and $p_\\phi$, and take gradients through the lower-bound objective, which are very general conditions satisfied for a variety of models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Transport Score Climbing\n",
+    "[Zhang et al., 2022](https://arxiv.org/abs/2202.01841) pose the question: suppose instead we wish to optimize the *forward* KI-divergence,\n",
+    "$$\n",
+    "\\textnormal{KL}\\{p_\\phi(z\\mid x)\\,||\\,q_\\psi(z\\mid x)\\} \\triangleq \\mathbb{E}_{p_\\phi}\\left[\\ln\\frac{p_\\phi(z\\mid x)}{q_\\psi(z\\mid x)}\\right],\n",
+    "$$\n",
+    "how could this be accomplished? The challenge here is that the expectation is with respect to the posterior and that is the exact thing we are trying to learn!\n",
+    "\n",
+    "There are several reasons why we might want to optimize the *forward* KL-divergence rather than the *reverse* one. For instance, optimizing the reverse KL-divergence is known to commonly exhibit \"mode-seeking behaviour\" that fits the solution to a single mode and underestimate posterior uncertainty, especially when the variational family is unimodal. Whereas, the forward KL-divergence commonly exhibits \"mode-spreading behaviour\" that fits the solution across modes and give a more realistic estimate of posterior uncertainty.\n",
+    "\n",
+    "The idea behind TSC is to approximate the expectation over the integral with samples that are drawn from an MCMC kernel having the posterior as its stationary distribution. Let us elaborate.\n",
+    "\n",
+    "\n",
+    "\n",
+    "It turns out that one can prove this algorithm minimizes the forward KL-divergence."
    ]
   },
   {

--- a/tutorials/transport_score_climbing.ipynb
+++ b/tutorials/transport_score_climbing.ipynb
@@ -1,0 +1,25 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Transport Score Climbing\n",
+    "This tutorial demonstrates a recently developed method for Bayesian inference called Transport Score Climbing ([Zhang et al., 2022](https://arxiv.org/abs/2202.01841)). We explain how the method works, how to implement it using FlowTorch, and demonstrate a simple toy example, replicating Figure 3 from [the paper](https://arxiv.org/pdf/2202.01841.pdf), and comparing to standard variational inference."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tutorials/transport_score_climbing.ipynb
+++ b/tutorials/transport_score_climbing.ipynb
@@ -7,7 +7,7 @@
     "# Transport Score Climbing\n",
     "This tutorial examines a recently developed method for Bayesian inference called Transport Score Climbing (TSC) ([Zhang et al., 2022](https://arxiv.org/abs/2202.01841)). We explain how the method works and how to implement it using FlowTorch. Then, we demonstrate TSC on a simple toy example, replicating Figure 3 from [the paper](https://arxiv.org/pdf/2202.01841.pdf), and comparing to modern black-box variational inference.\n",
     "\n",
-    "At a high-level, TSC works by combining an MCMC kernel with a normalizing flow to learn an approximation to the posterior. The normalizing flow learns how to Gaussianize the posterior distribution, and the MCMC kernel takes steps in the simpler Gausian space. The two are combined to draw approximate samples from the posterior, estimate gradients through forward KL-divergence, and train the normalizing flow.\n",
+    "At a high-level, TSC works by combining an MCMC kernel with a normalizing flow to learn an approximation to the posterior. The normalizing flow learns how to Gaussianize the posterior distribution, and the MCMC kernel takes steps in the simpler Gausian space. The two are combined to draw approximate samples from the posterior, estimate gradients through forward KL-divergence, and train the normalizing flow, thus bootstrapping each other's learning.\n",
     "\n",
     "We assume the reader is familiar with *Bayesian statistics*, *variational inference (VI)*, and *Hamiltonian Monte Carlo (HMC)*."
    ]


### PR DESCRIPTION
### Motivation
A new tutorial based on Transport Score Climbing (https://arxiv.org/pdf/2202.01841.pdf). TSC is a recently developed method for Bayesian inference that combines MCMC and VI ideas, making use of normalizing flows.

### Changes proposed
Adding `/tutorials/transport_score_climbing.ipynb` and `flowtorch.distributions.Banana`

### Test Plan
Ensure notebook runs without any errors.