### PR TITLE
Converted "Your First Flow" example to Jupyter notebook

### DIFF
--- a/tutorials/learn_bivariate_normal.ipynb
+++ b/tutorials/learn_bivariate_normal.ipynb
@@ -1,0 +1,340 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Your First Flow\n",
+    "## The Task\n",
+    "Let's begin our Normalizing Flow journey with a simple example! We'll train a flow to transform standard normal noise to samples from an arbitrary bivariate normal distribution.\n",
+    "\n",
+    "That is, the base distribution is,\n",
+    "$$\n",
+    "\\begin{aligned}\n",
+    "  X &\\sim \\mathcal{N}\\left(\\mu=\\begin{bmatrix}\n",
+    "   0 \\\\\n",
+    "   0\n",
+    "\\end{bmatrix}, \\Sigma=\\begin{bmatrix}\n",
+    "   1 & 0 \\\\\n",
+    "   0 & 1\n",
+    "\\end{bmatrix} \\right)\n",
+    "\\end{aligned},\n",
+    "$$\n",
+    "the target distribution to learn is,\n",
+    "$$\n",
+    "\\begin{aligned}\n",
+    "  Y' &\\sim \\mathcal{N}\\left(\\mu=\\begin{bmatrix}\n",
+    "   5 \\\\\n",
+    "   5\n",
+    "\\end{bmatrix}, \\Sigma=\\begin{bmatrix}\n",
+    "   0.5 & 0 \\\\\n",
+    "   0 & 0.5\n",
+    "\\end{bmatrix} \\right)\n",
+    "\\end{aligned},\n",
+    "$$\n",
+    "and the task is to learn some bijection $g_\\theta$ so that\n",
+    "$$\n",
+    "\\begin{aligned}\n",
+    "  Y &\\triangleq g_\\theta(X) \\\\\n",
+    "  &\\sim Y'\n",
+    "\\end{aligned}\n",
+    "$$\n",
+    "approximately holds.\n",
+    "\n",
+    "We will define our Normalizing Flow, $g_\\theta$, by a single affine transformation,\n",
+    "$$\n",
+    "\\begin{aligned}\n",
+    "  g_\\theta(\\mathbf{x}) &\\triangleq \\begin{bmatrix}\n",
+    "   \\mu_1 \\\\\n",
+    "   \\mu_2(x_1)\n",
+    "\\end{bmatrix} + \\begin{bmatrix}\n",
+    "   \\sigma_1 \\\\\n",
+    "   \\sigma_2(x_1)\n",
+    "\\end{bmatrix}\\otimes\\begin{bmatrix}\n",
+    "   x_1 \\\\\n",
+    "   x_2\n",
+    "\\end{bmatrix}.\n",
+    "\\end{aligned}\n",
+    "$$\n",
+    "In this notation, $\\mathbf{x}=(x_1,x_2)^T$, $\\otimes$ denotes element-wise multiplication, and the parameters are the scalars $\\mu_1,\\sigma_1$ and the parameters of the neural networks $\\mu_2(\\cdot)$ and $\\sigma_2(\\cdot)$. (Think of the NNs as very simple shallow feedforward nets in this example.) This is an example of [Inverse Autoregressive Flow](/dev/bibliography#kingma2016improving).\n",
+    "\n",
+    "There are several metrics we could use to train $Y$ to be close in distribution to $Y'$. Denote the target distribution of $Y'$ by $p(\\cdot)$ and the learnable distribution of the normalizing flow, $Y$, as $q_\\theta(\\cdot)$ (in the following sections, we will explain how to calculate $q_\\theta$ from $g_\\theta$). Let's use the forward [KL-divergence](https://en.wikipedia.org/wiki/Kullback%E2%80%93Leibler_divergence),\n",
+    "$$\n",
+    "\\begin{aligned}\n",
+    "\\text{KL}\\{p\\ ||\\ q_\\theta\\} &\\triangleq \\mathbb{E}_{p(\\cdot)}\\left[\\log\\frac{p(Y')}{q_\\theta(Y')}\\right] \\\\\n",
+    "&= -\\mathbb{E}_{p(\\cdot)}\\left[\\log q_\\theta(Y')\\right] + C,\n",
+    "\\end{aligned}\n",
+    "$$\n",
+    "where C is a constant that does not depend on $\\theta$. In practice, we draw a finite sample, $\\{y_1,\\ldots,y_M\\}$, from $p$ and optimize a [Monte Carlo estimate](https://en.wikipedia.org/wiki/Monte_Carlo_integration) of the KL-divergence with stochastic gradient descent so that the loss is,\n",
+    "$$\n",
+    "\\begin{aligned}\n",
+    "   \\mathcal{L}(\\theta) &= -\\frac{1}{M}\\sum^M_{m=1}\\log(q_\\theta(y_m))\n",
+    "\\end{aligned}\n",
+    "$$\n",
+    "\n",
+    "*So, to summarize, the task at hand is to learn how to transform standard bivariate normal noise into another bivariate normal distribution using an affine transformation, and we will do so by matching distributions with the KL-divergence metric.*"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Implementation\n",
+    "First, we import the relevant libraries:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "import flowtorch.bijectors as B\n",
+    "import flowtorch.distributions as D\n",
+    "import flowtorch.parameters as P"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The base and target distributions are defined using standard PyTorch:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base_dist = torch.distributions.Independent(\n",
+    "  torch.distributions.Normal(torch.zeros(2), torch.ones(2)), \n",
+    "  1\n",
+    ")\n",
+    "target_dist = torch.distributions.Independent(\n",
+    "  torch.distributions.Normal(torch.zeros(2)+5, torch.ones(2)*0.5),\n",
+    "  1\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note the use of [`torch.distributions.Independent`](https://pytorch.org/docs/stable/distributions.html#independent) so that our base and target distributions are *vector valued*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A Normalizing Flow is created in two steps. First, we create a \"plan\" for the flow as a [`flowtorch.bijectors.Bijector`](https://flowtorch.ai/api/flowtorch.bijectors.bijector) object,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Lazily instantiated flow\n",
+    "bijector = B.AffineAutoregressive()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This plan is then made concrete by combining it with the base distributions, which provides the input shape, and constructing a [`flowtorch.distributions.Flow`](https://flowtorch.ai/api/flowtorch.distributions.flow) object, an extension of [`torch.distributions.Distribution`](https://pytorch.org/docs/stable/distributions.html#distribution):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Instantiate transformed distribution and parameters\n",
+    "flow = D.Flow(base_dist, bijector)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "At this point, we have an object, `flow`, for the distribution, $q_\\theta(\\cdot)$, that follows the standard PyTorch interface."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can visualize samples from the base and target distributions as well as the flow before training:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXYAAAD8CAYAAABjAo9vAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAABB0ElEQVR4nO29f3wU9b3v//rsZpZskGww0mMqJHAtD6pkFzGItoLfI9seCRCt6Wmv5wQP1cc9VKmKua2K5UojvfSIeA9Jf6CHY49f26S3X6sRXTVeNdIDVC0GkSxCaUqFQEt7EcnyIwm7yX6+f8zOZnZ2PrOzu5P9+X4+HnlAZmdnPrNJXvOe90/GOQdBEARRONiyvQCCIAjCWkjYCYIgCgwSdoIgiAKDhJ0gCKLAIGEnCIIoMEjYCYIgCgxLhJ0x1swY+4gxtp8x9r8ZY6VWHJcgCIJInrSFnTF2GYD7AMzjnNcCsAO4Ld3jEgRBEKlhlSumBICTMVYCoAzAny06LkEQBJEkJekegHP+J8bYEwD6AQwBeINz/oZ2P8bYSgArAWDixIl1n//859M9NUEQRFGxZ8+eTzjnUxLtx9JtKcAYmwzgBQD/FcAAgF8BeJ5z3i56z7x583hPT09a5yUIgig2GGN7OOfzEu1nhSvmSwA+5pyf5JyHAHQC+KIFxyUIgiBSwAph7wdwHWOsjDHGAHgBHLTguARBEEQKpC3snPPfAngewAcA/JFjbk33uARBEERqpB08BQDO+fcAfC+dY4RCIRw/fhzDw8NWLCkvKS0txdSpUyFJUraXQhBEHmOJsFvB8ePHMWnSJEyfPh2yR6e44Jzj1KlTOH78OGbMmJHt5RAEkcfkTEuB4eFhVFZWFqWoAwBjDJWVlUX9xEIQhDXkjLADKFpRVyj26ycIwhpyStgJgiCI9CFhV3HkyBHU1tZmexkEQRBpQcJOEARRYOStsPv9frS2tuLRRx9Fa2sr/H6/JccdGRlBU1MTrrjiCvz93/89BgcHsX79elxzzTWora3FypUrobRh+OEPf4grr7wSHo8Ht90mN7Q8f/487rzzTsyfPx9z587FSy+9ZMm6CIIgzJKXwu73++Hz+RAIBAAAgUAAPp/PEnE/dOgQVq1ahYMHD6K8vBxbtmzBPffcg/fffx/79+/H0NAQXnnlFQDAY489hr1796K3txdPPfUUAGDDhg1YtGgRdu/eje3bt+OBBx7A+fPn014XQRCEWfJS2Lu7uxEKhWK2hUIhdHd3p33sadOm4frrrwcALF++HLt27cL27dtx7bXXwu124+2338ZHH30EAPB4PGhqakJ7eztKSuSSgDfeeAOPPfYYrrrqKvzt3/4thoeH0d/fn/a6CIIgzJIzBUrJoFjqZrcngzblkDGGVatWoaenB9OmTUNLS0s01/zVV1/Fjh074PP5sGHDBvj9fnDO8cILL2DWrFlpr4UgCCIV8tJid7lcSW1Phv7+frz77rsAgF/84hdYsGABAOCSSy7BuXPn8PzzzwMAwuEwjh07hhtvvBEbN25EIBDAuXPncNNNN+FHP/pR1A+/d+/etNdEEASRDHkp7F6vN66fiiRJ8Hq9aR971qxZ+MlPfoIrrrgCp0+fxt13341//ud/Rm1tLW666SZcc801AIDR0VEsX74cbrcbc+fOxX333YeKigo88sgjCIVC8Hg8mD17Nh555JG010QQBJEMaQ/aSAW9QRsHDx7EFVdcYfoYfr8f3d3dCAQCcLlc8Hq9cLvdVi814yT7ORAEUTyYHbSRlz52AHC73QUh5ARBEFaTl64YgiAIQgwJO0EQ40ZHBzB9OmCzyf92dGR7RcVB3rpiCILIbTo6gJUrgcFB+fujR+XvAaCpKXvrKgbIYicIYlxYu3ZM1BUGB+XtxPhCwk4QxLggKrimQuzxh4Q9wsDAALZs2TLu59m2bRsOHDgw7uchiGxTXZ3cdsI6SNgjJCvsnHOEw+Gkz0PCThQLGzYAZWWx28rK5O3E+JK3wm51tH3NmjU4fPgwrrrqKjQ3N8Pr9eLqq6+G2+2Ott49cuQIZs2ahX/6p39CbW0tjh07hu9///uYNWsWFixYgH/4h3/AE088AQA4fPgwFi9ejLq6OixcuBC/+93v8M477+Dll1/GAw88gKuuugqHDx9Ob9EEkcM0NQFbtwI1NQBj8r9bt1oXOKWMGwM45xn/qqur41oOHDgQt01EezvnZWWcA2NfZWXy9lT5+OOP+ezZsznnnIdCIR4IBDjnnJ88eZJffvnlPBwO848//pgzxvi7777LOed89+7dfM6cOXxoaIifOXOGf+5zn+ObNm3inHO+aNEi/vvf/55zzvl7773Hb7zxRs455ytWrOC/+tWvhOtI5nMgiEzS3s55TQ3njMn/pvP3ZsVarNaAfABADzehsXmZ7mgUbbfCGuCc47vf/S527NgBm82GP/3pT/jrX/8KAKipqcF1110HAPjNb36DW265BaWlpSgtLUVDQwMA4Ny5c3jnnXfwta99LXrMCxcupL8wgsgSHR3AnXcCwaD8/dGjwPLlwG9+A2QgNBXHeGtAvpOXrpjxjrZ3dHTg5MmT2LNnDz788EP8zd/8TbRV78SJExO+PxwOo6KiAh9++GH06+DBg9YsjiCywOrVY6Ku5sknx1wgimuEMaCkRP7Xbpf/ZQy45BLr3CWUcWNMXgr7eETbJ02ahLNnzwKQ+7p/5jOfgSRJ2L59O44ePar7nuuvvx4+nw/Dw8M4d+5cdLJSeXk5ZsyYgV/96lcA5CeAffv2xZ2HIHINkd/61Cnxe1avHitGUv5URkflf9X5BadOAXfcYSzuZv3mlHFjTF4K+3hE2ysrK3H99dejtrYWH374IXp6euB2u/Gzn/0Mn//853Xfc8011+Dmm2+Gx+NBfX093G53tCd8R0cHfvrTn2LOnDmYPXt2NAB72223YdOmTZg7dy4FT4mcQi3OnI9Viiaysk+dAr75zXjXiB6hkOwu0RPwZM5PGTcJMOOIT/QFoALA8wB+B+AggC8Y7Z9u8JTz3AnknD17lnPO+fnz53ldXR3fs2dPWsej4CmRaZS/JXUgUv1lt3PucIhfT+WLsfjAZ2Wl/r41NcbrzrYGZBJkOHjaBuB1zvnfM8YcAMoSvSFdmppyI0iycuVKHDhwAMPDw1ixYgWuvvrqbC+JIEyj7eeix+jomGvFKrRjIAYHxWs4elS26vv7ZVfLhg1jf/+5oAG5SNrCzhhzAbgBwDcAgHMeBKATZilMfvGLX2R7CQSRNB0dsm/cyHeeKzA25runRmLmsMLHPgPASQDPMMb2MsaeZowlTh0hCCIrKKmLuSjqdnv8Nj3rnhqJGWOFsJcAuBrAk5zzuQDOA1ij3YkxtpIx1sMY6zl58qQFpyUIIhXWrtVPXcwFzLp8jh6lSlMjrBD24wCOc85/G/n+echCHwPnfCvnfB7nfN6UKVMsOC1BEKlQKLney5cDF10k58dTW4FY0hZ2zvlfABxjjM2KbPICoC5XBJGjFFKu9/nzsktJSY+8804SesC6PPZ7AXQwxnoBXAXgBxYdN6P88Ic/xBVXXIHLLrsM99xzT7aXQxDjwoYNgMOR7VWMD8FgrNCbycMvRCwRds75hxE3i4dz/hXO+WkrjptptmzZgjfffBMbqMqBKECUoqDbbwcmTZLdGIVOsQZa87LyFIDlPTvvuusu/PGPf0R9fT1Onx67Lx05cgSLFi2Cx+OB1+tFf38/RkdHMWPGDHDOMTAwALvdjh07dgAAbrjhBvT19aW1FoJIBzNVnadOyeX+7e1yO91CplBiCsmQn8Keau2zAU899RQ++9nPYvv27Zg8eXJ0+7333osVK1agt7cXTU1NuO+++2C32zFr1iwcOHAAu3btwtVXX42dO3fiwoULOHbsGGbOnGnFVRJE0qxaJVvk2j+N1av1uyGuXj2WI16ocA5MmDA+zchylfwU9gxOyX333Xfxj//4jwCA22+/Hbt27QIALFy4EDt27MCOHTvw8MMPY9euXXj//fdxzTXXWL4GgjBDRwfw1FP6ed+inPVczGUfD9TpnadOyUHWQhb3/BT2HOjZecMNN2Dnzp3YvXs3lixZgoGBAfz617/GwoULM7YGglCzdm28qBP6BIOF7XvPT2HPYM/OL37xi/jlL38JQO7YqAj3/Pnz8c4778Bms6G0tBRXXXUV/u3f/g033HCD5WsgCDMY2TUmxggUBIyZ31fpQVOIlnt+CnsGe3b+6Ec/wjPPPAOPx4Of//znaGtrAwBMmDAB06ZNi05TWrhwIc6ePQu32235GgjCDIWUn54qixYlt//Ro3JMYtWq8VlP1jDTAtLqLyva9hZqz05q20ukit4cUPoy98VYfkgITLbtzU+LHZBbux05IudsHTlCrd6IoqepCdi6VU5zJJKD88LyudOvAEEUEE1NsePoiDEqK+UvEYWU755Tws6LPKRf7NdPEOPF3XcDn3wCtLWJA6yFFKPIGWEvLS3FqVOnilbcOOc4deoUSktLs70UIs8plgyYZHj2WTn7pakJuOuueHEvtHmpVo3GS5upU6fi+PHjKOZe7aWlpZg6dWq2l0HkOcmk/BULg4PAihXy/7dsAa6/Xvapa8ftdXTob883ckbYJUnCjBkzsr0Mgsh7zp3L9gpyk9HR2LF6WsHWzn/N5zF8OeOKIQgieSzuhVfwGHUeyWCnknEnZyx2giCSw8jCJMQk25EkH7NlyGIniBzGyCIXWZiUx27MxRfrb89gp5Jxh34FCCJHSdSdWmRJUh57amSwU8m4Q8JOEDmKyCJfsUK2yhNlv1B2jD6ffqq/XancramRP7uaGvn7fAucAuRjJ4icRWSRj47K/yYq+SjSkpCEGLlW9LJl8hGy2AkiR8lH324+kI+ulWQhYSeIHEXP55ssEyZYs5ZCobKyMCzyRJCwE0SOovX52u3JH+Oii+Q+KeRvl2+SkXEKBQ8JO0HkMOru1M8+C0hS7Os2m3HHwlOngOeeI397PgdCU4GEnSDyCK3lXVIiW6E1NeL9i2VgtYiamuIb2UDCThB5wtq18hBmNcpQZpE/vtgtdUkqjmCpFhJ2gsgTjEreFX+8kVumGCnW2AIJO0HkCWZK3oeGMrOWfEF5oik2SNgJIk9IVPKuV6lK5GcTr3SxTNgZY3bG2F7G2CtWHZMgiDESlbwnEjDGAIdj/NeZCZJJ/SzGQi8rLfbVAA5aeDyCIDQ0NckWenW1LORr1441BTMSMMbkQOqkSZlZ53ijtFVIRL428UoXS4SdMTYVwFIAT1txPIIg9DHq+GhUqapkx5w6lX5Asb1dnF6ZKUQWe2VlYTTxShdmxfBoxtjzAP4FwCQA3+GcL9PZZyWAlQBQXV1dd/To0bTPSxDFxvTpsphrUXK1OzqA1asT564rFnyyTJwovy+bvnyjtTNW2G2LGWN7OOfzEu2XtsXOGFsG4P9yzvcY7cc538o5n8c5nzdlypR0T0sQRUmiKT9NTXIbgURwnlqrgvPnsx+g5Vz81FGM/nQ9rHDFXA/gZsbYEQC/BLCIMdZuwXEJgtBgJuXRTBaIYuErrQr0sm0mTkx5meOOyGJfsiSz68hV0hZ2zvnDnPOpnPPpAG4D8DbnfHnaKyMIIg4zU34SWa3a/UXZNtm2zFPhtdeyvYLcgPLYCSKPMDPlR0/8FdeFKKCobjam9FVJxa1x0UXyuSors1MFW4w563pYKuyc81/rBU4JgrAOPRHWvq4V/5//XHZfJNMMS/R04PXG+7jLyuRsmbNn5XV98on8xbncNjiVlsOpIBpUXWyQxU4QBUgi8Td7DL2ng7fekm8UZtMKt2wBRkZk4U92cIjdHvsEoJwvl/3/uYAl6Y7JMm/ePN7T05Px8xIEkV06OuRh3GYKjMrKxDcMm00/gErpjjJksRMEkTGamsRZOHffbf4pwEx2UDFDwk4QREYRuXi2bNF3H3V0yIVZNpv8r6jKtljbB+hBrhiCIHIWpYWCOvVScdEAcq+c/n7ZUt+wofDbB5h1xZCwEwSRsyRqoVBskI+dIIi8J1ELBUIfEnaCIHIWCpKmBgk7QRihF7kjMgYFSVODhJ0gRBg1PycygpkWCkQ8FDwlCBEUuSNyDAqeEsWNFS4UitwReQoJO1F4WOVCocgdkaeQsGcKCsJljrVr45uJDw7K25OBIndEnkLCnglyPQhXaDcdq1woFLkj8hQKnmaCXA7CGdVs56uA5fLnTRBpQMFTK7DKks3lIJxVbotcYhxcKH6/H62trXj00UfR2toKv9+f5iIJYvwoyfYCchatJau4T4DkLdmLLwZOndLfnm2SuOn4/X50d3cjEAjA5XLB6/XC7XaP8wJTQPn5WNQhyu/3w+fzIRQKAQACgQB8Ph8A5Ob1E0UPuWJEiB7nKyvlwY7JCMYll+gLe2WlPD/MQpIWX5NuC624KTidTtTX16ckcPlyo2htbUUgEIjb7nK5cP/992d+QUTRYtYVQxa7CJEle+rUmEibteI//TS57SmSkmW5YYO+j13jtuju7o4TdQAYGhpKyXo1WqtyvqwLfkcHsHYtVh89ioDLhW6vF/s9nujLemKvR77cwIjCgXzsIszmKpvxR2coH1pPfEOhELq7u8VvMpn5YSRiCc+RxFq7urrg8/mi51MEP+M+bVUmEwNQEQigwedDbW9vdBeXy5XwMMoNLOvXQxQVZLGL0LNkRSQKgpq0itNl2s6d+EZ3N1yBQIyFmdCybGpK6E5yuVyGxzFrvWr3r+3thVdnzWqUG0dGrVydoLIjFIK3uxv7PR5IkgSv15vwMEY3W7LaifGChF2EXgDu3Dl9X3kiy9viYJ4uHR242eeDFBERxcIEgGMLFwJIzyXg9Xp1fewKiaxX7bmdTicu/+1v0eDzwaGzZq24J3vjSBvBzdqV5GcnWnfGr4coKkjYjdBasqtWAU8+Gb/fkiXR/wrFU88qjvhwLRH7tWujoq7gCIXwpbffRn9Li9Cn3d/fj76+voRir2zr6urC0NBQzGuJrFe9c9tsNni7u6Oirl6zYhWrUW4cep8vYN4nb/rmVl2tG1RmNTVJBUxFTzpm3DgEkSrkY0+G114z3J6UP9VsNarZXHqBhVkeCMDtdqOrq0vXJdDT06O/Xp3zut1uPPjgg2hsbMTVBw9i9ebNWNfSgm9t2oSq//k/hevUc0eEw2G4BFardrty49D7fF966SVs27bN1Geufn9tby++0dKCWo8Hwc9+Nv5ztSgX3uv1QpIk3eshiPGCLPZkSJDzncifqrYWm9vaUC4qDFKPZzebSy+yMKur4ff746xskW87FArh+MaNcL/4ovC8rldfxU2dnVFr2zUwAP7cc2MH1+wvdEe4XKjQeS1UVRW1dNVWdWtra9znOzo6Gv9+gQ9b+fnU9vbGuIAcJ07Ef64Wuc+UNVBWDJFJSNiTQSCeio/dyJ+qdUdMOn1a/xyR4/v9ftTce29i8VcwCNBqM1a0wqb1bX/hlVfE1ahNTah4/PE4FwrTXodqf5E7YufixVjc2RnjQgpJEv5y33267o5k/NJ6+yrb9FxAup+riaCyGdxuNwk5kVHSdsUwxqYxxrYzxg4wxj5ijK22YmE5iejxfMkSYPp0rGtpwerNm2NS4gDZn6q15gMiHytj6H/sMfh8PrH46z05aNIWg1VV6Lr1Vjz6hz/EiZyRbxuId4Uo8Mh5hesSrFPPHWGz2bCvthYvNzRgwOUCBzDgcuHlhga0h8NxrpRk0wP1fNjKNtH15USLB4KwACt87CMAvs05vxLAdQC+xRi70oLjZgcjn7ZezveKFcCzzwrznRV/qlZcD82cCd2aX85R8fjjCIVCYvEXZeE0NQFHjsC/bx+euOce7J45U3e3RL5t0XnPVlTI/06erH9+wTrdvb34zo9/HL3xze/rw4QJEzA6Oor9Hg/ampuxvqUFbc3NUXdQ9Ckj8vOo9Xh0b5oi9HzYyg1GdH0D5eXUB4YoCNJ2xXDOTwA4Efn/WcbYQQCXATiQ7rEzjgmftt/jQff990f9pasefxwOQb7zsYULo/5UxccKyK6Qufv2xbsvIigWcbfXG+MyAWAqgCeqElUQ+bYVwTs0cybm9/TErC8oSXjzxhvxVQADDz6I0nXrYtbFEeuOCZeW4vhdd+Gj5cvhfe65GLfPl557DoNDQ3GZLzFrCQRifh7qmyYQnw6pxul0Gmb2vHvgAL78y1+iROWfH7Hb0R25AasraalqlMhHLPWxM8amA5gL4Lc6r60EsBIAqnN1Ao2o0+Hq1cDateD9/ah2uTBt0SIEIoU/0okTuoeqOHMmxk+szgPX9fGqUARWES8lyHl28mSU/+hHun5fRYBERUpq9G4YQUlCt9ere9PhAPbOmRPNhw8sXYp9H36Iha+/HrXytfsHR0exZ88e3Pjmm3HXKglSGtW4XC5hkdBXXnwRjZ2dutcnSRLq6+uFx3W73XCXlwPaoKuqZ5L6iYGafxH5iGXCzhi7CMALAO7nnJ/Rvs453wpgKyA3AbPqvJaSoD8Mg5wBorYaRdZv1F0SyVV39/dj1qWXonvRIrGPF2MCq7Df44lWOjY0NOgKihKYnbVnj2FQVLE4t9lkD5xeVszqzZt1A6Oz+vrwycyZ+MEPfiBnlqj20T55MACloRCWvvRSXG69gtFnIEkSGoeH9QPVAOwRERZdn6HodnQATz0Vt7kkHI652QQCAaoaJfIWS4SdMSZBFvUOznmnFcfMCqKsFw3qIppurxe3bNuGknB4bAdJkt0lGteO48QJ1L/4IjBxInD+fNxxwwB8DQ0AgNWbN8MVCCDMGGycI1RVBUdNDaAjKEqOulFQ9FBdXdTvzDmP3jC0GPnfP/jgA4TD4bisGqPPSXQHH3Q6o9eovrEwxrDcZkP1979veGzt9R1buNBc4dDatTHWuRr1tRu1UKCqUSLXSVvYGWMMwE8BHOSc/2v6S8oiSfSHiRFAprFZle9Frh2bfsw65HAAQIxoKtapbq41EJOjbiTKDZEbhs/ng1GrZiP/ezhy81rc1ZVQ1BX04ggjdjsmXLiAiZF1VwQCaOzsRGNnp3wDCwbN9eiJ4AoEdIOluv5xg8wXxQWmBLzVcZGY81HVKJHjpN2PnTG2AMBOAH7IRicAfJdzLijTzPF+7Noyf0F/mAGXC23Nzbi/tRWugYH449TUyMdI4vPlkC3ZiZpiorjjKn3SOzpw5t57Men0aQRcLkjBoPi9NTXoWrBAmCmjoGeN612BKPCbiFHGMFxaaniN2kBsIoJVVXD8+c8x2/T6x0uShO/8+MfyTVLnnICc8TPw4IOoXrMGr776KrS/p0YuMYIYb8z2Yy/MQRtW9mDRmQkakiS83NCAYwsXYnVzs74IMWbataMmoagxBoTDuusasdkAxmKyPdQEJQm+hgbDoCUQW5WKROtJZu0YE9BUbwxxMIb+H/wAnaWlMZa5yNqe39cnu8NUn1vcuhkD5xxnKirw1qJFMZ/XvHnzsHTpUqtWTxBJUbwzT/V6sCxfDkyalNrMUp3cdemZZ/DVF17A/VOmgGndMArKDSXiXrEKJdc6+MADce6KknAYtnAYHPpWtroIyQgltzzgciUl6kGHA+edTnCMPbppGZoyBaymxtTxTJ2Xc7SHwzG9Yjo7O4V+8N0zZwJbtyJYVQUO+Qki7ho5jwmUq3Pn+/r6TK6MILJH4Qm7nl8bkF0qd96ZurgfOSJbykeOxPYRET3xKB0fk3wiGnQ6ZctbBw7gk4svNkyztEVESSTIRtko6ezLAEwIBiGNjGD3vHkI2+1x+4zYbOhauBD9d90VH5fQwBkT3hzUnJ082TBnX4vL5QKamrDlwQexvqUFtgQ/H+3NkAKnRD5QeMJuVBYeDMZOOzLbOTGVc732mnyuJESHAzhx6aVC0WMALv/4Y9T29oqrUk1gtnozlXM4QiHM27NH1x00WlICb3c3pj38sGEAFxi7QSXizRtvjNtW29sb7TyprlZVd1WMWvgmrtEVCESPQ4FTIh/ITR97Oj5y0XBmBQMfNcrKdMfCpXQuRZyT/HxHGYtmwohQgqwTLlyITbM0yXmnEyGHw7CICZAFMi6V0wQiX3uyQdGElJbijNMZDR4r+f96xVe+hgaU3nln1D+uDKg2m7qpHOcv69ejes0aK68iClW5EonI3+BpuoLb0QHcfrtYUJWsEpEoq7NO0jmX4ke2OniqYsRuhy0cTuhOSHQODmD3vHl4fdmy6Dan04mhoSHU9vZicVcXyoaGrBVlk4g+j1GbDRyIuekYBWYHXC68u2wZ6nftAvr7Ebz0Ury2YAH2zZ6dXLA4md+PJBBl8VAGDqEmf4OnotzvRAOjFZqagLvu0n/N4Rjrs5Kgt7ohigvn9tvjuz0CsrW+ZIl8Lk1Xw0SEE/ie1ZSMjoKlcGPWqxSd39MTdVk4nc7oa/s9Hjzx0EMYVG3LJINOZ7T74yhj0S6QwxMmxD1JJIoteJ97LhpUd5w4gZt9Pszv68N+jwf/b0sL9vf2grW3j92U9RinDpApDSInCAG50Y9d7XoRCVUyf1BbtgDXXy/3eFFy0Csrgba2Mas/QW91w7WqnyjOn5d99GqR4Ryhp5/GB++/j7pwOP5DrqwEvv51hJ5+OqbkngP4ePp0VB8/broASESybg8GucXAgauuihvKAQD7Z8+OawyW7jkTMWK34/X6el030bqWlqSOFWYs7jO1DQ+jftcu1Le3j21UxhiKnujGqc8RVbkSVpJ9YddzveiR7B9UoiEJOlWmIUnCy3V1ONbaKvZv6j1R6PigpUgQUddfftFFwJYt+OD992PEkgGoPn4ce+fMway+PrgCAVNCOWK3xwQrg5KEklAoaZF1BQK493/9r6jv/dDMmaj96COURYQ+kahzxlJ6ghBxweEQ5twLe/ToMGK3wy7I7RcZDP133YWqdetie92kMBrPLDQblbCS7Au7KD1RzXj8QalSFnl/P864XGPFKIIufn6/H7WRvutmEPq+I2JyxeHDccdyhEKY1deHtuZmU4E9BsA+OorRSE8ZRZDnp1gApohlRSCQ0ELXroNxbqnVXjY0FO0no7iCyoaGMOh0QrpwwdS5woxF89J10TEY/H4/fOEwZjU0RH3vZyoqEHjoIVRbMFFJD3X3TwWajUqkSvaF3cjFolRvplM5akTEqm+LZEio0XbxU4Jb05KwFMOiDJeImEzSa0WAsfQ6RdBKRkYMA6QMck8ZJc/dqNe7EXq+93SPkS7KZ61uQWDYckHFiM2GCxMmiPcXGAzd3d2YtWdPbPfLRYtwrLQU9xucL52sFpqNSlhJ9oVd5Oseh+wD0R+eGf+mEtzSG0KhR1CSsHfOHNTt3Rub060K4DKDlgNqQTPr3FDy3EVrs7ycfxxJx/JX0kFfr69HY6d+s1EOyAM8lKC8ynCYtnNnXPvjxs5ODHZ1oX94OK59gTKQQ9S7HTAn2DQblbCK7GfFiOaIWux6Uf7w1KXnPp8Pfr9f6MdUb1feN6uvL6GvOVBRAV9DA45XV4Np/e/BIPjy5Qjb7eBHj8aJtp6gJRsENXrNClEXtSww+14zx053nU889FC0X74e0c9CmZKlKk770ttv6/aknzg0hEvXrcO0nTsBxP4OibJaurq6hL93BDFeZF/Y9eaIJlMkZBKjdDK9Ycta/2bCQcgqygMBLHn9ddza2anrimEAbOFwVFwUMQtWVQmPmSuTSUZsNgw6neNm9Vtx81GnZnZ7vQgmSjnVpNOWC1xkQHyLAeV3SPTUNzQ0RGmMRMbJvrAD4l4sFmLkbnG73WhoaBgTb5crrjAkWoqeIEtBCSI6BwdNf7gsctw3//3fDS3MbKI09rKHw9EsmVSPM96oXV/7PR74GhqizcmE51fFehLl7Gtv7oqLJRkojZEYT7LvY88QidLJEvk33W43Ojs79QdMW7G+QAB79uzBsM7xLS/FT5F0rQDDtEMLcQSD0f+brpxVZcfYEhSJKTdfdcVqqKoqWsmqIEkSSkpKdOsCkk5jtLIVNVHw5IbFngHMuFsS4XK5ohagthoyXQIuV3Rknfr4Ay4XgoLWv2FkzkWTzo1FuY4Rmy2jNyil183ERKKuiemUGjyRqId+N/h8qIjUGqgrWYGxp776+vq0f+90W1Fr4gIEoSb3esWMI/2PPYaKxx/HpNOnYyblJPN+18aNKB8YiDadOlRXJ7ttGhqS7gujoPwE9BpyiRpxjdjtuOBwmE79yyZKL5pk8uLTIQzgxcZGLPX5UGrwZMUBuTe81voVVJ2OMoZtt94aHfotTHvVHDPt5l5W9DUiCgKzvWLAOc/4V11dHc847e2cl5VxLts88ldZmbw9xfeHAX7y61+Pvh6UpNjja/YNC17T7jcK8PfmzePPNzbyUcZ09xtlzNTxcuXL7PVb9TVisyU+X01NUj/rMMBPu1z8+cbGxMc2+t1qb5fPzZj8b6LfQcHvAGfM3O8uUTAA6OEmNDbhDuPxlRVhr6lJ7o/b7PsZi/5hfvDtb/MR0R9hCkI4mgOCbLW458pxw4CxoLa38wtVVbo3pKAk8ZDLlfg8er9bqRgY6f7uEgWDWWEvGh97Wt0cjfbjHFi7Fn6/H10XX5x0C10RDIUXAEmU/z8exxW+56KL5P/oDFp59dVXsf7wYfzLN7+pOx5QCoVQUlKi39lTjd7vTCrdSzNU60EUDoWmHWJETcTMNhcz2I/396OrqwuhUCityUbFTMazfoaGgDvuiAtI7v3Od9DT0wMeuUEL6xY+/XSs/kKE3u9MKgZGhmo9iMKheIQ9XatnwwahVXnG5YqmtJkqiCGyz+ho/NjCwUHMePrpmE3CG3V19Vj9RXu7+d+tVA2MDNR6EIVD8Qh7slaPdh4q5MwOrbgHJQlvLVoU/V5bEKMHB8AjaZLnnU6E7PacqSwtdrQWuu6NWivayfxukVuFyABFle6oi17hBxDXqz1cWooXlywBgNiuf4J5oYA8DEI0+3PTxo2WjJ7jkS/1e3OhmClfGXC50NbcHLNNW4jk2LQpPYuZio2IFDGb7lg0lae6aId8KIUfTmdcgMs2PAxvdzfampuFQq5FNAwiEHHdJDNIWYS2twpZ/uYYsdsBzmPqA0KShN7bbovbd7/HE/2Zu1wueD0eqLPQk85TTzQEhiDSpLiFXZShIBj8oTymqy04I6tdr/0AB3Bo5kwAsuVvdWsCstaN4Rhr6QvEP30dqq7GjKlTceTIEXDOwRiD+qlW3Y43UbteasFLZIviFvYkBxMHXK44K7siEEBD5A9ZK+77PR5M7e+PG383v6cHc/btwwSLRZ1IzKjNFjNHVVvlu+rxx+WRhJHq0daTJw2HsBh1DSVhJ7KFJcLOGFsMoA2AHcDTnPPHrDiukEQ+SrM+TINBF5CkmKwJpUeInpWtbuWqtQD1+rczwLDUnRg/SsJh3Z/VoZkzMXffvrGfbcQtN23xYgR0nsbU/dX1oO6NRDZJW9gZY3YAPwHwZQDHAbzPGHuZc34g3WPrIvCL9x87hs7SUkzbuRM3+3xjQ4gVvzkQL+4bNgC33y7nMWspL5eHTvf3I3jppXhtwQLsnz1bOJHHFbHctZa8NM4Crg2car/PZ5SfitnrMbu/KzIRSdlPON91cBBf3r5d182mbvFMQ6iJXCPtrBjG2BcAtHDOb4p8/zAAcM7/RfSetLJiBA2RAhUVaL3/fnFzJlHDJFGLVsbknGEA6OhA8IEHIJ04IZxjGo4Mk9YyKpp7SphCaXaWataQHsnc/JSfnDqWIklStF+/1scOIOZ1grASs1kxVuSxXwbgmOr745Ft2gWtZIz1MMZ6Tp48mfrZBH5xZeqNsFJQ5E8XVQ4qBSORJwTHiRPRodFaRux2MIF42zjHaIL+3qlSDLeLktFRlA4PW3a8ZJ9olKwj5QmstrdXbicQwcyQFoLINBkLnnLOtwLYCsgWe8oHEvjFlQpBUYqhurJPnZ42f8EC3PTXv8KmFg+HAzh3Ti5OstnkKkUtdjsQDmOgvBxSMChsnxtwuVB+5kxy12gCDiDocGCCaqhEoWLlE0+ifjVGryuxlP0eD7Zt2wZgbEALCTmRS1hhsf8JwDTV91Mj28YHncq9UCSwCSSuFNQOtd49cyZeXLIEg1OmyO6XykrZ537qlPyvaOJPOAyEw/jhf//vwlFxPLIekTWfDpwxfOjxFIXVngk45MpiZcCJ6HNVngjD4TC6uroytTyCSAorhP19ADMZYzMYYw4AtwF42YLj6qNTvn1i/XocqqsDMFbSH6ioANcp79ZLT9vv8WDTt74F/759csDUTMAz8gQwffp0+Tw68MixRa+nA+Mcc/ftK5hAaapYcWPjAP74X/4LXl+2DN1eL0btduHnGmYMtb29AKA78o4gcoG0hZ1zPgLgHgD/B8BBAM9xzj9K97iGaBoiVa9ZE+PnPLZwIfp37ADTaZhklIbW3d1tLrdd9QQw5Y03hBY5g5wbrRegtkKQrC5uyjdErpNkPlsO4OPLL8cL3/wmAGBxV1fMMGwtds6jvnaCyFUs8bFzzl8D8JoVx0oVkZ9T7U93Jpg+HwgExLntEZ+6Ni/+C6+8IrTuWE0Nvrx9O+w6r4VsNsBuT1mci91ST8SwJGFCKJTwc2IALvn006j1LXKrqVF87YevvTb9hRLEOFDQ3R21/vREj84ul0vcfe/ZZ3VbpoqycDgAbNiASZFsHS1SOIxQSQmGJYn85Cli5OIaLSnB4RkzogO/jfzmk06fTjrv3BUIoD7SloAgco2Cbimg508XEZ0cr1j9Jrvvhaqq4DhxIm77oNOJfz95EveUl6NER/wZgIlDQwhKEnbPm4drenoK+y47DgRLSnStcuWzrT5+HC82NkYLjL6zcaNu9tLZyZPh9Xrh8/lMp0OGqqqSyoRJe6A1QSRBQWuJ2bLuuNzjJIYa/OW++xDSZOEEJQmv19dj2s6dsCVIdXSEQpjV14cXGxsxYivoH4cuRpZ0IhL12nGEQmjs7MTqzZux+JVXdFNDR2w2DDz4YDQf3ZSLq6xMbt1rEu2To9IozO/3mz4GQSRDQSuJmcdrl8uF+++/PyXrye/3oz0cxssNDdE0uQGXC76GBgBAg89nagaqKxDAfo8HL33lK9HjFAvatsPJYGYMoVJcNL+nRzcoGiwtRfWaNUBHB9xGwm63pzyWzqhRGEGMBwXpilE/9hoRdb+kiPIHq+7XrbB682bTgVFFoJTjrGtpSXlN+YAV/WxG7HZ0e71Y3NUlLA5TIzqfc3Awvv+QlrKytGaMUqMwItMUnLDr9e5QULJihoaGLPFzGv1hClsbaFC6Rqp7vBNi1P3UlZvpLS+9ZJiiaETA5YKjuRllIlGPtO9NZzAGNQojMk3+C7umRe/xBQsQigyyUKO4XKxE9AdrJseZY6yxFIC0JynlE+lY6xckCU889FDsNocD9ojVrjwNiPLb1duVm6qoYycY028cByQ13k4JzGobhaXztEgQRuS3sOu08PX++c8YbGiIc42k9Ni7apX8CK62BlUWnN4fLCD3+U4kXqGqKvx41SqMjo4m5bYpdiaEQljX0hLTTVP9WYckCXvnzEHdBx/EjL0DgLDNhuEJE1A2NBTTrdHb3W3YX0hx7U3buRNf3r4dk06fBmNsrN3z0aMI3XEHThw7JvvrNShPhZQVQ2SK/B5mLWjhqzeQOGmLfdUq4Mkn9V8rKwNWrABeew28vx9nKyrw5o03Rm8moiHWWoJVVZAiqZJUcGQdAy6XsDGbaFh13BNTxK/u93jg8/kwa8+ehE9VgYoK9O/YQYJNjBuZbNubPQTl/1o/dUqPvVu3il8bHJRF/+hRMM5Rfvo0btm2LeqCMZOtASDaCphE3VpcgYCwglQvhqH0F1L3H1KCpUqA3Mx82vKBAcp0IXKC/HbFCMr/Q1VVUf93yo+9SQbjSsJh3NrZicbOTgw6nRix2eJcAckwYrdjxGYzVRZPxDLodCLkcOi6V8KMYV1LS9wQ8v0eD776wgtx+ysuPDNB7YAg5kIQmSa/hX3Dhvg0tbIy/OW++9I/tt2etLgrjz8Th4bAAYQxZo2bEWf1tJ5DM2diVl8fJgQCBTXuLhWSHZFnHxmJvk87NlDp7V4RCOCWbduwuKsLZUNDODt5MvC5z8UFQBUDQdjnP4ISiKVMFyIXyG9XjE4L3/5HHkF7OJy4yq+jQ/bR22zyvx0dsa8rc1JThEH+cBljpgWJQbY2pWAQ83t6UBEIkKsGyV//hFAIE1Wj9DhkS117nJJwOLpf+enT8s9c83vgNejzr1TNKkVph+rqKNOFyAnyO3iqQ2trqzBnOBo81StI0StCGaeRdkYUu3UuIt3PxfT7dWbjPvroowAQU2ugdeU4nU7U19dT4JQYV8wGT/PbFaODqSq/tWvjqwwHB+XtJgpROOTUOXsaPnQRuSzq2bzpZOy8SkBelaferMp60qbRUuoikYsUnLCbqvITDdPQbq+slEfk6dBz9dWY1dcHVyAAVlkJnDkjnrykznnOY6wSV/UnEbLZUMJ5dFjJeAm42eMGL70UDs0TXfnp02jw+QAgKuySJNHQaiJnyW8fuw5erxeSxhcal+6oGmwdg3Z7W5vubgzArL4+tDU3Y9PGjcAnnwDPPCPfCLSUlQF33ZXEFYjJ/1uDjBI3GLXbYQNg4zy6zegarbp+0XE4gNcWLEDwgQfinugcoRC+vH07AJ1uoASRYxScsCvtVxULXfePUDRMIzLuLoqBW0ZJf4sO72hqkgW+vR3BqqpoUK3r1lvhv/tu2XebJmzixLSPkUuUjI7GpYRmStz1uCBJ2Dd7drRoTEv5wAC+973vpdwNlCAyRcG5YgDxmLwoimCb6fVRU6ObKx9Q3TjU+D0e+O65J9pmoLa3F9MWLgSP3AjULoERux0XHA6UDQ1h0OnEhGBQ2MwqKEkY4Rxluq+OUcjB1yGnExzy+Lp0rlH0XqW/uyi18UxFBY76/STqRM5TkMJuiqYmcx37dHLllZxlvYpWde9tvVJ1da66OqsCAJqefRaXf/xxXO610s1Q2KxKw4DLBVcgEO2nwpF/j2ZxBV6ShNKREdiS7KmTzI1OuVm/u2wZ6l98Me5n/uaNN+JQxNdO4k7kMvn29555VLnynDGcmTwZvoYGHFu4UNfPqg7c6pWhMwBDZWVoa26OEfXa3t44UVf2Dzkc2O/xYDDBMG5Avgl8cvHFABBtkqXM/cw1Rux23XUxyDNLg1VVYyX+5eWGoi66vgsmZ8qqb9ZTH3oI2LoVZyZPjslT3+/x0IAMIi8oXos9GSLWPQNQDuCrBruqs3JEZejOwUHU9vbGCLtRR0izPdpHAZydODHuBlGC3BF2bXXtfEE9gyMYBNu0acxdZiKrKChJMTfScGkpwjYbWAIrP2yzjd2sldRFtxub//AH3f2pbQCR65DFbkSi6lQdvF4v5nz0EVZv3izch0EWcjVG4q24CESNrQBgsKwM2xob8TeffKJ7g8gVvzuDXAXqioyrM1zXypVyfMOEqIcZg081onBwyhTYnn4azgTTlcKlpbD97Gf46gsvxAVFmaBATbSdIHIFsthF6PR6j7YZMPDNu3t7Mdvng2142PDwWiEXBew4EB3GEWYs2uskBrsdh997Dwe2bTPth88muteggTEmHlWng43zmAIiSZLQ4PHALWgUpww6eXfZMtQLfp6iqmzOecz4RSpSInINsthFGFWnJnhfIlEH5A6UastP1Ivkg+uuw+FrrwUA8WDs0VG43W585StfSXjefIDDQFQF79G2So76wnVSW4OShM7GRrQ1N2O3zrQtBVFDL6fTCZ/Pl7gfEUFkCRJ2EWarU5N9HQDKyuDYtAm33nprdJPSE1xxJQy4XHjpa1+DY+tWOBwOAAZ93u12oKMDbrcbzOImVLnim1cIOhxxa1ICn1oCgUA0+K0XCAWM546Kit0AxE3NoqAqkUuQsIswW52q9cNHMlLisNvjhji43e7ogG1AFvdurxeBSLrikl274O7tjVqGelY9ALm98B13yGt56y0ggbibFeugJGH3vHn65zTJiN2OYZOZKQqijpYjdjvsIyOxrzGGA9dcE9fDBVCJdlMTjv7nf+JfNmyIy0aaaWCxi4rdhgR+ewqqErlCWj52xtgmAA0AggAOA7iDcz5gwbqyj6DXe0x1qp4fXpIAhwMIBmPfp+0cGeG2cBiu1laUDwzEFSk5TpxA6I47cHVjIz644oqoIN3a2Rl/Rw6FMLhyJTb94Q9wLVuGxi99CdXr1sX1rxmx27Fn7tyxPjc6l64etL3f48Hx6upo33KzYUP1Mbzd3SgViJ6ZPHPlWLrj7jjHlR9/jCMffYS/feONaOfFX//d3+HyRx6J7uZ2u9Hf3w9tV9F9+/ahurpa6B/XK3ZTfOtaqBc7kSuka7G/CaCWc+4B8HsAD6e/pBxBp9d7nDjr+eFDIWDSJOP3Reh/7DFUrVsH18AAGOQBHdrKUykUgtfnw+rNm7GupcUwLdIZWUsgEEB7OIz+9euByspo3/DzTmeMqBuhtmz3ezx44qGH0NnYGHUVGVnhah/2fo8n4bkCFRXRNRqtR5QV5DhxAjf7fNH+9RWBAG72+eCOjCpU6Ovri3tvKi4UU/2ICCKLpCXsnPM3OOcjkW/fAzA1/SXlEE1Ncm/ucFj+VyvOIn/6p58avw+A3++Ha+NGSCYqKZ2DgzGiZYZQKITO0lLgk0+wvqUF61ta8Hp9Pebu22dqgEci63O4rAyHZ8zAKGNRUdb6sBe/8gr+R6SXuQhWWYn+HTvQtnkzwoI0QmW7UYxBG7C2DQ/HBbpNtXQ2keJqqh8RQWQRK9Md7wTw/1l4vNxHkEon9M+r6O7uxuqBAVOn0atG1UNbmRotlIoUTZkZyAwA7KKL5KEkHR04c++9mHT6tOwmunAhWuZfEQjEuXKUIOZ+jwe3vPEGrko0TMVuB9raxtwdv/89+JNPxrVUCJWUoLa3F91eb1yLBpSVidMiNTfehC2dk0hxTdiPiCCySEKLnTH2FmNsv87XLap91gIYASCs4GGMrWSM9TDGek6ePGnN6rON2S6ROihzNBNh1GJWzYjdjtfr6+P2a21txcyZMyFJkukKVpw/HxW58tOnx9xEOp0Y1ThCIXi7uyFJEua8957xORiTRVMtmFu24IPrrkM48hSgnKM0FEKDz4cypxO+hgY5w0Xt5hJ1ztTcYBO6UFJNcSWIHCPt0XiMsW8A+CYAL+fcVEXJeI7GyziqSTuGXSI1tLa2YtrOnXEW6IjNhgsTJqBsaEgcMIRcaRqMiLVeQzE1kiRhzpw5WLB8OVwmnhJGXC6UVFToP40kgAPY39sLt2AtMTgcwH/8R8zn5ff7MW3hQn2Xk87YOgDmRx1Gji8sLLLZ9KtcGZPdagSRZcyOxktL2BljiwH8K4D/h3Nu2gwvKGFPEb/fD5/Ph1l79kTnaJ6pqEDgoYfwS5stmlKn1yEyKEn4y/r16CwtjQrUzJkz0dfXJ/Qju1wu3D9lCsL/7b8lLKBKq/WvIr4lJXIaZiIqK+U+9urz22zRiUoxGAlsijfYGKZP17+ZiW4oBJFhzAp7ulkxPwYwCcCbjLEPGWNPpXm8okEJwB1buBBtzc1o27wZ/Tt2oHrNGtTX10ddBnqFS91f/zqq16yB1+uN+o37+voMszKUYh3b009HO1WKbunJpDSqCUoSuhYswKOPPooPr73WXO66zuhBZraGQE2iQLcZ0nCtEUQukbYrJhXIYk+M3+9HV1dXXDGMMmsTAHw+X0wFpCRJKCkp0S2gcblcckAUwKuvvoqenh6sa2lJyjJXDwZRujMqqZN67qAlr72Gebt3Jz6H9ndQz7UCyNZ9W1tqom0WKyx/ghgnzFrs1AQsR1GyLkQ+4dbWVt2y9pKSEkiSFCf4amt+z549ptehSG6oqgrdixbF9VZ53eC9/VOnonb//mh+vZBLLokVbOXf1atjLfpTpxC64w6cOHYM1WvWmL6GpDA7gIUgchgS9hxHlFYn8qUPDQ3B6XRGLXe9zoPKU5qwW6T6PC4X2pqbowFYad++uBuK0+mMe0rQiw0IOXUKuPNO+f9qcV+7Ns5VI4VCcG3cCP/SpZRuSBACSNjzFHVOdm1vbzQAq7hEDtXVobGxUVf8GGPgnKOnrs6wJzoHcChioYdCIfT19aGhoUH4BDFt587oOszcNGIIBmUhV1vLggKw8oEBdHd3k7AThAAS9jzF6/VGs2rUlnFFIICGyFzO7rIyXfGrq6tDT08PXl+2DACE4s4AzN23D8erq7Hf40EgEBA+QTQOD+NS1TqSEnUFrZALCsACgkIjgiBkqLtjnqJk1Xx5+/Y4d4dSKCQSv6VLl2LePDn+8vqyZYaFUsqxAEGbgUgJfvXDD5tzu9jt4te0WS8bNiCkKShSqlup4RZBiCFhz2PcbjfKBQVHrkAAzW1twp4nS5cujYqjsB2w6li6Ta6U7BWzhUxlZfL+eudyOOLTCpuacGL9+miTMKUPzaG6uow03PL7/WhtbcWjjz6K1tZWGqRB5A2U7pjvCIpq4oqMdCoxlSKpUCiE2t5efOXFF3VdKGcmT8bR//zPeBeMqKBHjd0u55arUwc7OmIzXhKkMWZjDJ36s1FQUk3Jt09ki4xUnqYKCbuF6OR8CytHdSoo1aI5v68PN73wQmxlqkEveWEJvpn35jitra3ChmFKPQBBZBrKYy8WFNFUFdUwkRWtk2USFwytrzdfoCPqbgnIN5E8Lu4x1eKXIHIU8rEXAtpyejPdDkV9x5MpzReV4Le3p17WnyOIgrMUtCXyARL2QiRRzxN10JPzsb7jOkMlDDEzZSpPoSlJRD5DPvZCxajnCXUxNEU2grYEYQQFTwkxFvYdJ/EjiMyRqba9RD6SSltcHZSUQCWgGAgE4PP5KN+bILIMCXsxYlHf8e7ubt0Ok92RSlWCILIDCXsxYlHQk1ICCSI3oTz2YsWCvuMuQTMuSgkkiOxCFnuhIspTT3U/HSglkCByE7LYCxFtmwElTx2ItdLN7idAyX6hrBiCyC0o3bEQMZunTvnsBJFXULpjMSOYPBS33ex+BEHkFSTshYjZPHWL8tkJgsgtSNgLEbN56hblsxMEkVuQsBciZvPUC7iJF0EUMxQ8JQiCyBMoeEoQBFGkkLATBEEUGCTsBEEQBYYlws4Y+zZjjDPGLrHieARBEETqpC3sjLFpAP4OAFW1EARB5ABWWOybATwIIPPpNQRBEEQcaTUBY4zdAuBPnPN9jLFE+64EEOkwhQuMsf3pnDvHuQTAJ9lexDhSyNdXyNcG0PXlO7PM7JQwj50x9haAS3VeWgvguwD+jnMeYIwdATCPc57wQ2WM9ZjJxcxX6Pryl0K+NoCuL98xe30JLXbO+ZcEJ3ADmAFAsdanAviAMTafc/6XJNdLEARBWETKrhjOuR/AZ5Tvk7HYCYIgiPEjW3nsW7N03kxB15e/FPK1AXR9+Y6p68tKrxiCIAhi/KDKU4IgiAKDhJ0gCKLAyLqwF2I7AsbYJsbY7xhjvYyxFxljFdlekxUwxhYzxg4xxv7AGFuT7fVYCWNsGmNsO2PsAGPsI8bY6myvyWoYY3bG2F7G2CvZXst4wBirYIw9H/nbO8gY+0K212QVjLHmyO/lfsbY/2aMlRrtn1VhL+B2BG8CqOWcewD8HsDDWV5P2jDG7AB+AqAewJUA/oExdmV2V2UpIwC+zTm/EsB1AL5VYNcHAKsBHMz2IsaRNgCvc84/D2AOCuRaGWOXAbgPctZhLQA7gNuM3pNti70g2xFwzt/gnI9Evn0Pco5/vjMfwB8453/knAcB/BLALVlek2Vwzk9wzj+I/P8sZFG4LLursg7G2FQASwE8ne21jAeMMReAGwD8FAA450HO+UBWF2UtJQCcjLESAGUA/my0c9aEXd2OIFtryBB3AujK9iIs4DIAx1TfH0cBCZ8axth0AHMB/DbLS7GSVshGVDjL6xgvZgA4CeCZiLvpacbYxGwvygo4538C8ARkz8YJAAHO+RtG7xlXYWeMvRXxCWm/boHcjmDdeJ5/PElwbco+ayE/4ndkb6VEMjDGLgLwAoD7Oednsr0eK2CMLQPwfznne7K9lnGkBMDVAJ7knM8FcB5AQcSBGGOTIT8dzwDwWQATGWPLjd6TVhOwRBRyOwLRtSkwxr4BYBkALy+MYoE/AZim+n5qZFvBwBiTIIt6B+e8M9vrsZDrAdzMGFsCoBRAOWOsnXNuKA55xnEAxznnylPW8ygQYQfwJQAfc85PAgBjrBPAFwG0i96QFVcM59zPOf8M53w653w65B/K1fki6olgjC2G/Nh7M+d8MNvrsYj3AcxkjM1gjDkgB29ezvKaLIPJFsZPARzknP9rttdjJZzzhznnUyN/a7cBeLvARB0R7TjGGFO6H3oBHMjikqykH8B1jLGyyO+pFwkCw+NqsRcxPwYwAcCbkSeS9zjnd2V3SenBOR9hjN0D4P9Ajsr/B+f8oywvy0quB3A7AD9j7MPItu9yzl/L3pKIJLkXQEfE8PgjgDuyvB5L4Jz/ljH2PIAPILt29yJBawFqKUAQBFFgZDvdkSAIgrAYEnaCIIgCg4SdIAiiwCBhJwiCKDBI2AmCIAoMEnaCIIgCg4SdIAiiwPj/AcdhqtIhRnXXAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "plt.axis([-4., 8., -4., 8.])\n",
+    "\n",
+    "base_samples = base_dist.sample((1000,))\n",
+    "target_samples = target_dist.sample((1000,))\n",
+    "flow_samples = flow.sample((1000,))\n",
+    "\n",
+    "plt.scatter(base_samples[:,0], base_samples[:,1], label='base', c='grey')\n",
+    "plt.scatter(target_samples[:,0], target_samples[:,1], label='target', c='blue')\n",
+    "plt.scatter(flow_samples[:,0], flow_samples[:,1], label='flow', c='red')\n",
+    "\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since `flow` follows the standard inference for [`torch.distributions`](https://pytorch.org/docs/stable/distributions.html), it can be trained with the following code, which will be familiar to PyTorch users:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch 0 loss 20.42441177368164\n",
+      "epoch 500 loss 3.5910611152648926\n",
+      "epoch 1000 loss 3.3313257694244385\n",
+      "epoch 1500 loss 3.024606704711914\n",
+      "epoch 2000 loss 2.4530959129333496\n",
+      "epoch 2500 loss 1.5909523963928223\n",
+      "epoch 3000 loss 1.478494644165039\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Training loop\n",
+    "opt = torch.optim.Adam(flow.parameters(), lr=5e-3)\n",
+    "for idx in range(3001):\n",
+    "    opt.zero_grad()\n",
+    "\n",
+    "    # Minimize KL(p || q)\n",
+    "    y = target_dist.sample((1000,))\n",
+    "    loss = -flow.log_prob(y).mean()\n",
+    "\n",
+    "    if idx % 500 == 0:\n",
+    "        print('epoch', idx, 'loss', loss.item())\n",
+    "\n",
+    "    loss.backward()\n",
+    "    opt.step()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note how we obtain the learnable parameters of the normalizing flow from the `flow` object, which is a [`torch.nn.Module`](https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module). Visualizing samples after learning, we see that we have been successful in matching the target distribution:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXYAAAD8CAYAAABjAo9vAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAAAwa0lEQVR4nO3de3Bc1Z3g8e9pqWW1IIhEwE4Fo8dMtAZsWYAFSXhtoDMThOPAeDO1ODJ4htk4wPBwaipUQJUwzpSpTEhlRRgM40yWSpBIdkIcE8VohiDIGg8kIAWMYpzEAUuymezEmKBgW7Ye/ds/Wrfdat1Xd99+/z5VKlA/7j3dcv/u6d/5nXOMiKCUUqp8hArdAKWUUsHSwK6UUmVGA7tSSpUZDexKKVVmNLArpVSZ0cCulFJlJpDAboz5rDFmtzHmF8aY7xhjaoM4rlJKqfRlHdiNMWcCtwMdIrIMqAKuy/a4SimlMhNUKqYaiBhjqoE64D8COq5SSqk0VWd7ABF50xjzVWAcmASeEpGnUh9njFkPrAc46aSTVpx99tnZnloppSrK8PDwWyJyutfjTLZLChhj3gt8H/gfwDvA94DHRaTX6TkdHR0yNDSU1XmVUqrSGGOGRaTD63FBpGI+CuwTkYMiMg1sBS4O4LhKKaUyEERgHwc+ZIypM8YYIArsCeC4SimlMpB1YBeRnwGPAz8HRuaOuSXb4yqllMpM1oOnACJyD3BPNseYnp7mwIEDHDt2LIgmlaTa2loWL15MOBwudFOUUiUskMAehAMHDvCe97yH5uZm4hmdyiIiHDp0iAMHDtDS0lLo5iilSljRLClw7NgxGhoaKjKoAxhjaGhoqOhvLEqpYBRNYAcqNqhbKv31K6WCUVSBXSmlVPY0sCcZHR1l2bJlhW6GUkplRQO7UkqVmZIN7CMjI/T09LBx40Z6enoYGRkJ5LgzMzN0dXVxzjnn8MlPfpKjR4/ypS99iQsvvJBly5axfv16rGUYvv71r3PuueeyfPlyrrsuvqDlkSNHuPHGG7nooos4//zzeeKJJwJpl1JK+VWSgX1kZIT+/n4mJiYAmJiYoL+/P5Dg/qtf/YpbbrmFPXv2cMopp7B582ZuvfVWXnrpJX7xi18wOTnJj370IwC+/OUv8/LLL/Pqq6/y8MMPA7Bp0yauvPJKXnzxRZ599lk+97nPceTIkazbpZRSfpVkYB8cHGR6enrebdPT0wwODmZ97LPOOotLLrkEgLVr17Jz506effZZPvjBD9LW1sYzzzzD7t27AVi+fDldXV309vZSXR2fEvDUU0/x5S9/mfPOO4+PfOQjHDt2jPHx8azbpZRSfhXNBKV0WD11v7enI7Xk0BjDLbfcwtDQEGeddRZ/93d/l6g13759Ozt27KC/v59NmzYxMjKCiPD973+fJUuWZN0WpZTKREn22Ovr69O6PR3j4+O88MILADz22GNceumlAJx22mkcPnyYxx9/HIBYLMb+/fu54oor+Id/+AcmJiY4fPgwH/vYx3jggQcSefiXX3456zYppVQ6SjKwR6PRBeuphMNhotFo1sdesmQJDz74IOeccw6///3vufnmm/n0pz/NsmXL+NjHPsaFF14IwOzsLGvXrqWtrY3zzz+f22+/nVNPPZUvfOELTE9Ps3z5cpYuXcoXvvCFrNuklFLpyHqjjUzYbbSxZ88ezjnnHN/HGBkZYXBwkImJCerr64lGo7S1tQXd1LxL931QSlUOvxttlGSOHaCtra0sArlSSgWtJFMxSimlnGlgV0rlTF8fNDdDKBT/b19foVtUGUo2FaOUKm59fbB+PRw9Gv99bCz+O0BXV+HaVQm0x66UypxLl7y7+0RQtxw9Gr9d5Zb22JVSmfHokjtNuNaJ2LmnPfY577zzDps3b875ebZt28Zrr72W8/MolXMeXfLGRvunOd2ugqOBfU66gV1EiMViaZ9HA7sqGx5d8k2boK5u/l11dfHbVW6VbGAPerT985//PK+//jrnnXcen/3sZ4lGo1xwwQW0tbUllt4dHR1lyZIl3HDDDSxbtoz9+/fz93//9yxZsoRLL72UNWvW8NWvfhWA119/nauuuooVK1Zw2WWX8ctf/pLnn3+eH/7wh3zuc5/jvPPO4/XXX8+u0UoVkluXvK+Pru5mDh8Nsb+qmU/RR1MTbNkS3MCpVty4EJG8/6xYsUJSvfbaawtuc9LbK1JXJwInfurq4rdnat++fbJ06VIREZmenpaJiQkRETl48KD8yZ/8icRiMdm3b58YY+SFF14QEZEXX3xR2tvbZXJyUv7whz/IBz7wAbnvvvtEROTKK6+UX//61yIi8tOf/lSuuOIKERFZt26dfO9733NsRzrvg1L51Nsr0tQkYkz8v8/d7PBBjEbjD3L7gKYeLM0Pr10M+Mtwr7zbMHfMhob4T4bHL1bAkPiIsSU5eOqW2guiNyAi3H333ezYsYNQKMSbb77Jf/7nfwLQ1NTEhz70IQD+/d//nWuuuYba2lpqa2tZtWoVAIcPH+b555/nL/7iLxLHPH78ePYNU6pA+vrgxhthair++8VjfSx+qBvhKKaqCmZnoakJrr4aHn44HmuTJX9A7QZdr78e1q6NH2PTJs8PcmoMWEMf/zi9npMOzd146NCJOyuwzrIkA3uuR9v7+vo4ePAgw8PDhMNhmpubE0v1nnTSSZ7Pj8VinHrqqbzyyivBNEipArvjjhNB/QFu4RYeJsRc8J6dhbo6dl69ieYt3Sx2WH9KxsY4clozJ3N4Yc/Meo7PIJz6Wb+Xbk7iqP2DIdieXwkoyRx7Lkbb3/Oe9/Duu+8C8XXdzzjjDMLhMM8++yxjY2O2z7nkkkvo7+/n2LFjHD58OLGz0imnnEJLSwvf+973gPg3gF27di04j1JFpa+Pw6c1EzMhRk0zt5/Wl8hbWx3gNfTND+qWo0c5+6E7eP+sc+/KACcfGkOSe9N2jh5ldG23a9489bPeiI9eXQXVWZZkYM/FaHtDQwOXXHIJy5Yt45VXXmFoaIi2tja+/e1vc/bZZ9s+58ILL+QTn/gEy5cvp7Ozk7a2tsSa8H19fXzzm9+kvb2dpUuXJgZgr7vuOu677z7OP/98HTxVxaOvj5kb13PyoTFCCM2M0XPoetasNcSqqpnFsI9m7ueOhUF9TgOHOMT7PE9lPB8RD9RW590uuKfGgHF89Ooqqc7STyLe6wc4FXgc+CWwB/iw2+OzHTwVyXrsJTDvvvuuiIgcOXJEVqxYIcPDw1kdTwdPVcYy/FD09orsr2qaPxLp8BPzuP93NMhh6rI+zj6aEr82NXm/3P9bE3U/ZrbVFUUCn4OnQQX2bwH/c+7/a4BT3R4fRGAvFmvWrJH29nZZsmSJ3HvvvVkfr1TfB1VgGZaKWU+bJaWKJcOfGMi/EpVpqjyDt9sx1tA772bX61Vv78IqnNQnl0FQF8ljYAfqgX3Mbdrh56ecAnvQ9H1QGWlqcg5qNnp749WA1sP24fD8DANzts9PvskYkTX0yu9okNjc/ZMnN5wI1k6v3XpyGfEb2IOoimkBDgKPGGPagWHgDhE5EsCxlVJ+pFEqllq6CHA3m/gG690rS3zyk0P3Eps7SowQIYktOG7t4UPxFwHug6KVlFdPEsTgaTVwAfCQiJwPHAE+n/ogY8x6Y8yQMWbo4MGDAZxWKZWQRqlYd/f8oA7wHbp4hHWJgFpIJumnaq5Ftq2amoq/GKfXbkzFrl8QRGA/ABwQkZ/N/f448UA/j4hsEZEOEek4/fTTAzitUirBqVTs6qsXzLtP7uCuoY99NDOL4W94yLHipVjJ2Bjr39rEEVJeuzFw000VU7eeKuvALiL/D9hvjFkyd1MU0FWulMqnrq74QixNTfGg1tQEH/5wfBbo2Fg84zw3w/ORuluA+ESjXq6nmTFC+EuhFFvYn6WKbxzp4tNsYZQmYhj2h5rokkdpfnJzxa4fE1Qd+21AnzHmVeA84N6AjptXX//61znnnHM488wzufXWWwvdHKXS09UFo6MQi8V78M88Ew/oyUS44chDxDLsoRc+UTNfiFkgnkq6m02M08iZsXE20c3FY32OdfDlLpAlBUTkFaAjiGMV0ubNm3n66ad5+umnGRoaKnRzlEpPX1885zw+Hk+9pAb1OcUWnLMxThMQTyklD/42M8Y3WA9Hobu7q+IyMiU58xQIfM3Om266iTfeeIPOzk5+//vfJ24fHR3lyiuvZPny5USjUcbHx5mdnaWlpQUR4Z133qGqqoodO3YAcPnll7N3796s2qJU2qyFtay0y+xsoVuUcwL8ig+wj2b6WLugouckjnIv3ZW0kkBCaQb21H/EbnOPfXr44Yd5//vfz7PPPst73/vexO233XYb69at49VXX6Wrq4vbb7+dqqoqlixZwmuvvcbOnTu54IILeO655zh+/Dj79++ntbU1iFeplH92S56WOQP8Kc/QzJjjt5BGxhGBRYviQw/GwGmnlX96pjQDex53yX3hhRf41Kc+BcD111/Pzp07AbjsssvYsWMHO3bs4K677mLnzp289NJLXHjhhYG3QSlPldgtBc8xAmsNmf8+ZVX/hBg61My/resr6+BemoG9CHbJvfzyy3nuued48cUXufrqq3nnnXf4yU9+wmWXXZa3NiiVUKETcdwcoY672ZTIv8erf+ILnH1rdi2dN5Rv1700A3sed8m9+OKL+e53vwvEV2y0AvdFF13E888/TygUora2lvPOO49/+qd/4vLLLw+8DUp52mRTy12hBBiliU+zhe/QZbtWuwHeFzvE0evXs/OW8gvupRnY87hL7gMPPMAjjzzC8uXLefTRR7n//vsBWLRoEWeddVZiN6XLLruMd999l7a2tsDboJSnri7uatjCbFnVvGQmRohGxrmXbtbQ57pWe50cZfFD3dxySx4bmA9+FpQJ+ieQRcCKZd3egOkiYCpTvb3xfT8nCQe2oFep/xymTn5Hg+tjZjFiTGmEEHwuAlaaPXaYPxljdLRipw4rZenqgo8+0sVf8wgHaSi6WaKFYKVg3N6LcRoRyUntRcGUbmBXSi2Yz9FFH4/RxRm8xYPczCym4gN8A2/zFg2298Uw3E08hVtOhUVFtZm1iGBM5eYIxWGmoFK2+vpg3boTk5HGxmDdOtbM3f1XfIuqig/rcIj30R+9nxtfWD+vTDqGYTM38R3i3/bLqbCoaHrstbW1HDp0qGKDm4hw6NAhamtrC90UVSo+85mFM0xnZ3mYz9hWglSy217oYue6+CJpAsxQBQgf50nW0Jer2ouCMYUIpB0dHZK6Fsv09DQHDhzg2LFjeW9PsaitrWXx4sWEw+FCN0WVAodvtwIIpuSW4M0VAbro5V+quvjJ+j4u/dbCnrtBME1N7Lx6E2uf7GJ8PN6D37SpuIbvjDHDIuK5LlfRpGLC4TAtLS2FboZSZSFGKLHyYaUzEF8QbBYaH+4Gmf9NJnEBHBvj/IfWczEwRldipRIoruDuR9H02JVSaaqqileFpRDKawXHoIzSRCPjnt9kRmmihdHE701N8cK7YuC3x140OXalVHp+ecVnbEOUBnV7jYwn1o7xelyyUqyW0cCuVBFzW536qt9s5kFuZkZrX3wRDD/iao56LL2QGvxLsVpGA7tSRcpanfrisT7ekGbeGAtx2fXNibVNxsfhNjZzA98qcEtLQxUxPs03eaxmXTy/AgsGoK2FwyylWi2jgV2pItXdDdccnb8yYaPEB/i6TF8iJt1Lt6ZffFrEFB+dejKeNBeBRx+dt0/syzdv4fmmrsS2sVu2lN7AKejgqVJFKxSCN6SZZsYW3Jc8wDdLSEsb0xDDEJKFg86lQAdPlSpxjY0LB/IS9yXd7mdAUJ1wtKH83y8N7EoVqU2b4ICxD0LJwfxudC12v45Tw8n3l2DSPE0a2JUqUl1dMH7TJo6a+UE7dYDvO3TxabYwShMxDDHNuM8jcz+zhNgX/evSTJqnSQO7UkXs0s1d1D1qrXFiGEvaGQjiefiGhnhwb2GUKmIVu56j06s2cz9VxDj7hW+V7XZ4yTSwK1Xs5vYeeKw3xn+tGU0EdYDqarj//hPVe8pDjja9LzYa2JUqEd3dMDU1/7apqfjtybtFOq09Xu58J6BKcSppmjSwK1UinOLR+Hi8U79lSzwtcwf3c4zKXiHUyqvbKsWppGnSwK5UiXCKR8m3T07G8+038khiMPUgDRW3VZ6VV1/wmkt1KmmaNLArVSKS0y2W5DjV3X1imfHkwdQzeIszeIsxij8RH/TFxzC3qUapTyVNU2CB3RhTZYx52Rjzo6COqZQ6wUq3JM2AnxenvFLH3RVa7x4iVnGb3gfZY78D2BPg8ZRSKbq64j30xsZ4IO/uPlG955Y6NgYeo4vPnhSvd3frGRcyZeM2AGrVosdIr42VMNM0VSCB3RizGFgJ/HMQx1NK2bNWfBwbi69hZe3y09dnn6qxWEtCfeNIF39sRl0rZwQoxpVUrFr0Sep8V/7MVoUrYqZpqqB67D3Anbj8ezDGrDfGDBljhg4ePBjQaZWqLMl5dItVmp1cGeNGBDZwv2Ovd5wmNnNz0Q62Wpt0+5lhW3XqKRWTfkmWdWA3xnwc+J2IDLs9TkS2iEiHiHScfvrp2Z5WqYrkVvII8Rh28snex3mMLr590s0LgqO1XMFtbC7qpQlO45C/GbZvv537xhShIHrslwCfMMaMAt8FrjTG9AZwXKVUCj8lj37m3zQ1wbrDmwn1PsrhhnhZ5GjScgV1dRT10gRWOaOnCqhZt5N1YBeRu0RksYg0A9cBz4jI2qxbppRawKvkEbxj2bzHd3Vx8lujfKc3xkeaRvmu6UpU24znuTzSdVJRJiqkZt2O1rErVUK8Sh7BPvhbuy05lXLPLUczryrwaw0LyyOzTc+4Be63aOBBFqaHjhHmIA2uy5sJJCZiVVrNup1AA7uI/EREPh7kMZVS89kF4dT7k4P/bQ19/OF9zYgJMUozXfhb3fCD93dxa/jEcsCjNPGN0E1MpSxXMEWI49R4Hi+G4UFuZpqqBfdZAft5LmEtj8475408whm8RRUxx0lWYzRxBm9xTsNbFVezbktE8v6zYsUKUUrlQW+vSF2dSLwY5sRPQ0P8Ph9Pb2oSMSb+3+du7hWpqZl3rOPUyJ7ozSce2NCw4DFSVyfP3dwrdXUiD3CzxFLbM/dzmDpZQ2/ipqqqE4dsaBD5FL1yxNQ5PqehIddvaGEBQ+IjxmpgV6qcNTXZBlAr2PoJ7r6O19Q0/3GpV4S58/T2iozi0iaQfTS5N6+3V/bRJLMY2UfTvAuBMem+QaXFb2DXzayVKmeh0InZSXaamuJpi2yPZ0w8BeKDmJBrxU0Mwx83xdi0yTmb0twcn5yVKt2XU2p0M2ullHeJTLprk/upt/RgmtwfG2pqnJci7+uLB/JQKP5fp1m2FVwEs4AGdqXKmds6A5B+nXcQEdWtTSnHclpCAbyrgyqan3xN0D+aY1cqj3p746OKQeTYrePZ5M8zOoY1Qmrl6VOO5TelXynQHLtSap6+vviiMuPj8Z66WxK7SASQ0i8rfnPs1flojFKqCHR1FX0gT9XYaD9IWqErBfimOXalVNHSQdLMaGBXShUtP0soqIU0FaOUKmolmEEqOO2xK6VUmdHArpRSZUYDu1JKlRkN7EopVWY0sCulVJnRqhilfBgZGWFwcJCJiQnq6+uJRqO0tbUVullK2dLArnyr1OA2MjJCf38/09PTAExMTNDf3w9QEa9flR4N7GUmV8HXLrht3bqVgYEBOjs7MzpHqVwoBgcHE6/bMj09zeDgYFG2VykN7GUklz1Lu+AGMDk5mdE53Npqna9YAv7ExERat6cqlQuYKh86eFpG3HqW2XILYpmcw6mtAwMD9Pf3J85nBfyRkZH0Gx2Q+vr6tG5PZl3Aiun1qPKngb2MZNuzdOMVxNI9h9PjJycnc3ZxylQ0GiUcDs+7LRwOE41GPZ+by4utUk40FVNG6uvrbQOmFZSzSQlEo9F5qROnczhJPXckEmFyctLXuSGYi1OmrPcok/culxdbpZxoYA9YIfOpdsHX6lk65bTHx8fZu3evZ3ut2wYGBhYEZK/eq925Q6EQVVVVzM7OzjtOdXW1bcB3uziB/6Cb6d+nra0to7+j18VWqVzQwB6gQpfFufUsv/KVr9imBJJ3svJqrxXcRkZG5gX46mr3f0Z26YhYLEYkEqGmpmZBkE7n4vTEE08gIsTmttNxew2F+Pu4XWyVyhUN7AHyKovLR2/ermc5MjLiO+3ht4xvZmYm8f9elTFu+fQ777zT9j6796mnp2fB+5vc4/d6DYUoW8wmjaNUpjSwB8gtn5pubzHIi0C6A3VWe53On26AdEpHRCIRenp6mJiYwBiDiCTOtWHDBtt2pfMa/D4/1/nuTNM4SmUq68BujDkL+DbwXwABtojI/dketxS55VPTCYZBpAySA3O6wuEwW7duTfyeev50A6RdOiIUCjE1NZX4JmFtqu70WtMtD7TLYWu+W1WKIModZ4C/FZFzgQ8Bf2OMOTeA45Yct7K4dIJhtiVyqbXT6bKrfEk+f7p13W1tbaxatSpxf319PYsWLbJNo6Sey5Lutw67HLbT36e1tZWenh42btxIT0+P1pirkpd1j11Efgv8du7/3zXG7AHOBF7L9tjFyC1F4ZZPdeo9JwdDr16230DtNEs0W9b57XrgVVVVTE1NsXHjRttqlUgkMu9YXjn/1NeazkUqEom4VvYk/31aW1vZtWuX47cjnTWqSlGgOXZjTDNwPvAzm/vWA+sBGhsbgzxt3vhJkTjlU72qI7Zv3z6vQsWOW8ogm9SLX8nnr66uTryWmpoaZmZmEsF6YmKCbdu2YYxJ9MqTA7mfNqa+Vqc0SqpwOExnZ6fj/al/H7sB2eRvDLr4lypFgc08NcacDHwf2CAif0i9X0S2iEiHiHScfvrpQZ02r7JJkdilI1atWpXoFXoFdbcSOb+pl/r6elavXk0olNmfvbW1lXvvvZetW7fOC9RTU1OJckNLLBZzTLV4sXutdmmUVMnvqV9u34501qgqVYH02I0xYeJBvU9Etno9vlRlmyJx6s17BQqvFMDAwIBn6iU5WFoDlen6+c9/viCAB80YYxucrd9/8IMf2La/vr7etpLGi9uAqs4aVaUqiKoYA3wT2CMiX8u+ScUrV1UVboHCK2D5qVFPnfyTaWDPdVAPh8OuPW7rdr8Tfvzkx91SZH7GRZQqRkH02C8BrgdGjDGvzN12t4g8GcCxi0quZhG69Q69ju3W2zfG8MUvfjHxu10+uVDC4TDt7e22yxlkOkCdzG/JqNvxxsfHF6TIdNaoKgVBVMXsBEwAbSl6uZpF6LTAVkdHh+ex3Xr7IkJPT0+ijcWSQnALxl/5ylcWDLR6DVCPjIwkJjpZx/YzbyD1ArJ69ep59+3atWtB29vb23XgVBU9nXmaplzNIkyuMolEIgt2JXLqxXpViyQHRr+VJbnU0dHBypUrF9ye2sNO5jar1WlnJyfW6/fq0TuVjO7du9fHq1SqsDSwF5hdQJuZmWF8fHxeDfjx48dtF7pqbW31rKixAqPX0rv5MDQ0RGNjo691XJI5XZDSrdm38uNePXodOFWlTAN7gTkFmORgbTc4mm7ZnVdPNp8GBgYSFy1rjRgvxph5k5+sC0M6gTY5P+4VuHX5AVXKNLAXWDY9wGLrPfrdPGNycnLBGjFenNaSSSe9lJwf9wrchVhuV2e5qqDo1ngFljrVvlik2676+nqWLl2ao9bMNz09TX9/P1/60pfSurgl58e9trtzm1CWC7o3qgqS9tgLaGRkhKmpqUI3Y4F0g3py3Xe+ZDJOkHwR8FPhlM/ldguxVrwqXxrYc8DvV+rBwcGMp907SR1oTVcoFEprL1JjTCLFUSw5fDfJ5Z/FtE66DtaqIGlgn5NJftNp/02/C0fl6kObaVA3xqT9XBHh5ZdfTjw/01mt+eJ3Ia9857t1sFYFSQM7/mcpJn/YI5EIU1NTiR639ZzkenSL01fqXNSVp9PbThUOhzNKDc3OznqWXBYTrxSH7o2qSp0GdvzlN1M/7E4liE65X7sAXgx15cmKMd+fK24X1Ezz3dn08nVvVBWkigrsTh88P/nNbDevsPtKnfphVvm1fft221mwXnvX2v0bcuvlg7+AXUw5f1XaKiawu33w/OQ3/QbeSCTCzMyM61dqp+BgrXei8sNpFqxTPX44HHb8N+TUyx8YGJj370E361D5UDF17G5fr71qmsHfIJa1e49b/bNdvfLWrVvZvn275lMLIJ0STbtUm/VvyOmCPDk5qZt1qLyrmMDu9vXaz2QUr6BrPQfcv3Y7pXSGhoYYHx9P+3Wp7Nj9u0h3ANr6W2d7XqWCUjGpGK90i1d+06tOe8OGDb6qKdw+0MPDw94vRAXKLiCnW61kXcDtqlqqq6ttLxRaxqhyqWJ67H7SLV6cPox+VgwEPKeHF3sNeLlx+vv72V819RhO3/o6Ozuz/nenVLoqpsceRDmZV62xV3WN5lWLi9PaL36rlVL3Z3X71qdljCqfTCF6iR0dHVJKE1qSudUqO1W1RCIRampqss6rGmOora3NahKSivO7+fXIyAjbtm1bMCO3qqqKa665RgO0yitjzLCIdHg9rmJ67EFx65XZbXoRCoWYmppyDcZ+p+JrUPfP7T31mwqxLuKpQd1uhyuliokG9jS5TVCx2yPTa+2VUCjEokWLfK9jrvxxu1B6Lb+7fft2hoeHFxwjHA7ndOlepYKigT0NblUvAwMDac9Mtdab0YAdPKcee319vWdQd0oT6jK6qlRUTFVMEJyqXvr7+9MOzvX19dTU1AS+bK+KW7FiRUbVKF4lp1p/rkqB9tjT4PShTrenbgWYUli/vFQ1NjbS2NjomDZzGgD3GuvQ+nNVCjSw+zQyMpLVeuPWc+vr62ltbWVgYCDgFqpkg4ODiaoXK4gPDg4yPj7Orl27HCeRBTHoqlShabmjD6m59Uy0tLTw9ttv61f5PKqpqUlrKeL6+nre9773sW/fPtfHpNah6ybUKl+03DFA2S7ZC7gGi1ThcLho1mgvZemuLz8xMcHRo0dpaWlhdHQUEVnQg0/t4RdiUw6lvOjgqQ/57GUbY6irq8vb+dR809PTvP3223zxi1/knnvu4ZRTTrF9jDWL2GsZCaUKIZDAboy5yhjzK2PMb4wxnw/imMUknwNmIqLpmgJLfv+9lonQTahVMco6FWOMqQIeBP4UOAC8ZIz5oYi8lu2x05HLPKfTGjG5SJdEIhGOHTumC4IVUPKF3GtVUN2EWhWjIHrsFwG/EZE3RGQK+C5wTQDH9c1u84r+/n7P1RT9clq5L+gPbygUYnJyUoN6AVlLQGzcuJGenh5aW1td6+GDWDVUqaAFMXh6JrA/6fcDwAdTH2SMWQ+sh3iNcZAy3Xw4HU5rxARZi+61/IDKLWMMxpjEZLOJiQl27dpFe3s7u3fvTtxeXX3iY6ObUKtilLeqGBHZAmyBeLljkMdON88ZVNrGa/MNVVpEZMFM4OnpaXbv3s3x48cTt01OTrJt2zbgxAVfA7kqJkGkYt4Ezkr6ffHcbXnjtQFGMrc9RzNhjMnoeap0TE5OLvg2FYvFdJKZKlpBBPaXgFZjTIsxpga4DvhhAMf1LZ08p9ueo5nk5Jubm9N+jio+VVVVaT9HF29TxSrrwC4iM8CtwL8Be4B/EZHd2R43HX42o7a4laFlUnv89ttvO96nlRGlwdoIRalyEUiOXUSeBJ4M4liZcspzJufTI5GI6zEyqT12e86GDRscd1VSxcNrd6tIJGLbO/f696RUoZT1zNPUfLrXV+dMethe+f1oNEooVNZvc8mzBtHt1NfX09nZuSBVU1VVRWdnZz6ap1TayjripLPGS6a1x0472k9MTNDT0wPAokWL0j6uyh+rMsppnKatrY1rrrlmXqov3f1OR0ZG6OnpSdTHBzXHQik7Zb0ImN8USLa1x9XV1bYXEGuilC7oVbyqqqrm/e2dymCzKWnUhcJUvpV1YHea7p36GD+71dvxs5zv9PR0Vuu4q9yqqakJJHi7yccEOqWSlWVgTx4wdZPt1G+/qR4R0aV4i1Q+ShZ1oTCVb2WXY08dME0WiUQSlQxuJZF++f1gGmNob2+fl6NVxSPTyWl+pTOBTqkglF2P3akXnU3KxYmfVA/Ee+y7du2adyHRMsjiYe3mtXLlypwc32l1UF0oTOVK2QX2fH7ttfvAOknNqUajUZ544okFa5OowhgeHnYM7E5rC/ldc0gXClP5VnaBPZ/rY6d+YL0kP8Z6rgb34uA0uG1X0bJ169YFfzevShddKEzlU9nl2PO9PnZbW5vvFI/dxUUnLxU3p9Se3cVYt8RTxaLseuyF+trrlW+3u7gEsUm2yq10U3g6bqKKQdkF9lxyy6m65dudLi4aBIqHW+VKOn8nrXRRxaDsAnuuZvl5HTeTbwrpBg2VnUgkwtKlSxNVMMlaW1ttnxONRn1vpqKVLqpYlF1gz9UsPz/HTXeALJ2qmlyotElTx48fT2zLmBrcd+3aRWNj44K/n99dsiKRCJ2dnTpAqopC2Y3c5arcMejjWmkda8kBiPfgOzo68jKgGg6HWbVqVc7PUwhOu1rFYjEGBwfZu3fvgvvcBj7d0iv19fWsXr2aO++8U4O6KhplF9hzNcvPae3tTNbkHhkZ4YknnkhcFEQksRjVypUrufbaa+fNUl29ejWrV6+2XUUyU8UW1LNd2zwcDtPR0UE4HHZdl2diYsL1Im236qJTpdXq1avZsGGDBnRVdMouFVMKs/wGBgYWlMvNzs4yMDDguTlycg4/m28hbW1tiWWFCy0SiTAzM5PVMaanpxkeHvZcbM3aLcnpvbMbj9EJRqrUlF1gz9WH0GmxKLvbvWYkpnOsZKkBP5tlCTZu3JjR84IWDoeZnZ21zfVbq2LW19czNTXl+f74WUHz+PHjLF26lF27dtme02k8RicYqVJSdoEdcvMh9Duj1Wmm4sDAgK/BtY0bN/qetl7owdcguLVdRLjnnnsAf0sk+xGLxdi7dy+rVq1yHBRN/jv7XTZAqWJSloE9F/ymeJwmHU1OTia+5ntVo1illOPj4/N6ll4lluUm+aJpvdaBgYGsl9qdmJigra3N8X2zzqsbZKhSVXaDp7nS1tbGqlWr5g1q2i376xZgra/51dXe11MrZ+xUYpncrg0bNpTlxBi7cZGpqSnfz3eqjknej9Zt+Qm3Elelipn22NPgJ8XjNaiZTs/aKWdsd4xy67FHIpEF7/Xg4KDvBdOstIld+sbajzYajbJq1SrHVItukKFKlQb2gHnlva3eYrbBwQpMVhAqp1ms4XCYzs7OBben8/paW1tdU1VWWmXVqlWOi7g5bWno9E1AqWKhgT1gbrng5K/52Q4EpuZ7o9Eo27ZtIxaLZXzMYmDtNmX3zSidi1fyTFKrtDP1uV4zkp2+MYmIDqqqoqY59hxoa2vjzjvvZPXq1bY5eStf76fnl7ydX6rkfG9bWxvXXnvtvMeWYs/S2m3KaaJQVVWVr+Ok5sIzSas4jVtEIpF52y9aF1m7NitVCNpjzyG3nLx1u9s6JFZKYnBw0LESJHXzjtTzleIWfHY9aauHPDs7Oy9FEolEfL03mWzA4lQJZbXRq81KFYr22Auora3NsTdujEn08N0Cs9dUfLvKj1IwMTHBxo0b6enpYfv27fN6yCKSmNJ/5513+lpGwul9cFrVEZwrofxcSJQqJONntp7jk425D1gFTAGvA38lIu94Pa+jo0Pslk6tRHYTb0KhEIsWLWJyctLXrMv6+npaW1vZu3evbc53+/bttkvVFpoxhtra2ozr0q0Nyu3eQ2uRs+QetN37YPc4L07fgnKxYbpSyYwxwyLS4fW4bHvsPwaWichy4NfAXVker6LYrfAYiUQwxiSC3cTEhGft9sTEBENDQ445X7vVDO20tLRk+lLSFg6H+fM//3M6Ozsz/kZhvV6/cwzSXdXRSb63X1QqXVnl2EXkqaRffwp8MrvmVI7UXqaVXoCF+2lmstl1cs7XT4ogEolwww03JNqWy9msdmuXZ3K+1JmpXr3uoOrSdVEwVeyCHDy9Efg/AR6vrDnNagxy3RcrYPkpE0yuG08OkpkOvianSbwCYPL5/C5OlkkPOZMBVCe6KJgqZp6B3RjzNPBHNnd1i8gTc4/pBmaAPpfjrAfWA4ldbCpZvgbaenp6aG1tdVzNEOK57q1btzI4OLgg8DpVhixevJjR0VHbWu/koJtuAHSqcgmHw9TV1WXVQy6FJZ2VCkJWg6cAxpi/BD4DREXkqJ/n6OCpc0/YrXwv+TEzMzO+e/fhcJj29nZ2797teWy7wcTkXrfXubNNS4yMjCyYaBUKhbj22msD6SHrxCJVyvwOnmZbFXMV8DXgv4nIQb/P08BuXw1jBVU/KxiuXr16XoBKroqxY5cacZoy71Td4bV0blBVIRp8lbLnN7Bnm2P/R2AR8OO5qo6fishNWR6zIngNwHkF0NTn7927l2g06rnGuJUacSuBdLo4OC1JnPw865tINgFZ89dKZSfbqpgPBNWQSuQUwPysN+O0VrhTKid5gNCrrt1pMNHPuEBqyWXy61FK5YcuKVCkrKDvlJbo6emxraqprq5esJFH6gDh8PCw43mTLxyp5013Bcmgptlrakap9GhgL3JOvXqnADs5OUkkEqG6ujoxczU1ELqNq7S3twPYfhtob2+3ra7xu15LJnQXI6XSp2vFlCi32uvJyUlmZmZYvXo1GzZsWBAA3VZ93LVrFwMDA7bfBqy9QpNneKazXksmdBcjpdKnPfYS5bWhh1saZMWKFY45drdJUtZeoXbHzFWNuO5ipFT6NLCXKD8bWTvdvnLlSoC0FwZz633napp9kLNFlaoUGthLmNvuQOAe/FauXOlY9243CclP7zsXZYqFnC2qg7aqVGmOvQxkutqg0/M6Ozt9rZaYD35XbgyaNWiruySpUqQ99jKQaRrE63nF0jstxIQlt0HbYnlflHKigb1MZBr8dJanPR20VaVMUzFK2chV+aZS+aCBXSkbukuSKmWailHKhu6SpEqZBnaVlXIuCdTxB1WqNLCrjOk6LkoVJ82xq4zpOi5KFScN7CpjWhKoVHHSwK4ypiWBShUnDewqY1oSqFRx0sFTlTEtCVSqOGlgV1nRkkClio+mYpRSqsxoYFdKqTKjgV0ppcqMBnallCozGtiVUqrMaGBXSqkyo4FdKaXKjAZ2pZQqM4EEdmPM3xpjxBhzWhDHU0oplbmsA7sx5izgz4Dx7JujlFIqW0H02P8XcCcgARxLKaVUlrJaK8YYcw3wpojsMsZ4PXY9sH7u1+PGmF9kc+4idxrwVqEbkUPl/PrK+bWBvr5St8TPg4yIe0fbGPM08Ec2d3UDdwN/JiITxphRoENEPN9UY8yQiHT4aWAp0tdXusr5tYG+vlLn9/V59thF5KMOJ2gDWgCrt74Y+Lkx5iIR+X9ptlcppVRAMk7FiMgIcIb1ezo9dqWUUrlTqDr2LQU6b77o6ytd5fzaQF9fqfP1+jxz7EoppUqLzjxVSqkyo4FdKaXKTMEDezkuR2CMuc8Y80tjzKvGmB8YY04tdJuCYIy5yhjzK2PMb4wxny90e4JkjDnLGPOsMeY1Y8xuY8wdhW5T0IwxVcaYl40xPyp0W3LBGHOqMebxuc/eHmPMhwvdpqAYYz479+/yF8aY7xhjat0eX9DAXsbLEfwYWCYiy4FfA3cVuD1ZM8ZUAQ8CncC5wBpjzLmFbVWgZoC/FZFzgQ8Bf1Nmrw/gDmBPoRuRQ/cD/yoiZwPtlMlrNcacCdxOvOpwGVAFXOf2nEL32MtyOQIReUpEZuZ+/SnxGv9SdxHwGxF5Q0SmgO8C1xS4TYERkd+KyM/n/v9d4kHhzMK2KjjGmMXASuCfC92WXDDG1AOXA98EEJEpEXmnoI0KVjUQMcZUA3XAf7g9uGCBPXk5gkK1IU9uBAYK3YgAnAnsT/r9AGUU+JIZY5qB84GfFbgpQeoh3omKFbgdudICHAQemUs3/bMx5qRCNyoIIvIm8FXimY3fAhMi8pTbc3Ia2I0xT8/lhFJ/riG+HMEXc3n+XPJ4bdZjuol/xe8rXEtVOowxJwPfBzaIyB8K3Z4gGGM+DvxORIYL3ZYcqgYuAB4SkfOBI0BZjAMZY95L/NtxC/B+4CRjzFq352S1CJiXcl6OwOm1WYwxfwl8HIhKeUwWeBM4K+n3xXO3lQ1jTJh4UO8Tka2Fbk+ALgE+YYy5GqgFTjHG9IqIa3AoMQeAAyJifct6nDIJ7MBHgX0ichDAGLMVuBjodXpCQVIxIjIiImeISLOINBP/o1xQKkHdizHmKuJfez8hIkcL3Z6AvAS0GmNajDE1xAdvfljgNgXGxHsY3wT2iMjXCt2eIInIXSKyeO6zdh3wTJkFdeZix35jjLX6YRR4rYBNCtI48CFjTN3cv9MoHgPDOe2xV7B/BBYBP577RvJTEbmpsE3KjojMGGNuBf6N+Kj8/xaR3QVuVpAuAa4HRowxr8zddreIPFm4Jqk03Qb0zXU83gD+qsDtCYSI/MwY8zjwc+Kp3ZfxWFpAlxRQSqkyU+hyR6WUUgHTwK6UUmVGA7tSSpUZDexKKVVmNLArpVSZ0cCulFJlRgO7UkqVmf8PlS67Cn+ltsEAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig = plt.figure()\n",
+    "plt.axis([-4., 8., -4., 8.])\n",
+    "\n",
+    "flow_samples = flow.sample((1000,))\n",
+    "\n",
+    "plt.scatter(base_samples[:,0], base_samples[:,1], label='base', c='grey')\n",
+    "plt.scatter(target_samples[:,0], target_samples[:,1], label='target', c='blue')\n",
+    "plt.scatter(flow_samples[:,0], flow_samples[:,1], label='flow', c='red')\n",
+    "\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Congratulations on training your first flow!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Discussion\n",
+    "\n",
+    "This simple example illustrates a few important points of FlowTorch's design:\n",
+    "\n",
+    "Firstly, `Bijector` objects are agnostic to their shape. A `Bijector` object specifies *how the shape is changed* by the forward and inverse operations, and then calculates the exact shapes when it obtains knowledge of the base distribution, when `flow = dist.Flow(base_dist, bijector)` is run. Any neural networks or other parametrized functions, which also require this shape information, are not instantiated until the same moment. In this sense, a `Bijector` can be thought of as a lazy plan for creating a normalizing flow. The advantage of doing things this way is that the shape information can be \"type checked\" and does not need to be specified in multiple locations (ensuring these quantities are consistent).\n",
+    "\n",
+    "Secondly, all objects are designed to have sensible defaults. We do not need to define the conditioning network for [`bijectors.AffineAutoregressive`](https://flowtorch.ai/api/flowtorch.bijectors.affineautoregressive), it will use a [MADE network](https://flowtorch.ai/dev/bibliography#germain2015made) with sensible hyperparameters and defer initialization until it later receives shape information.\n",
+    "\n",
+    "Thirdly, there is compatibility, in as far as is possible, with standard PyTorch interfaces such as [`torch.distributions`](https://pytorch.org/docs/stable/distributions.html).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "4a889874aef137a58c8f92e3ed6912ec441c66e3cc8f3752c91ed486cb306b1b"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.8.5 ('base')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
### Motivation
There are currently three basic tutorials which are written directly in MDX format. We would like to convert these to Jupyter notebook so they can be run by users locally and on Colab. Related PRs: #94, #95

### Changes proposed
This PR converts the "Your First Flow" tutorial to Jupyter notebook format. I have converted `website/docs/users/start.mdx` to `tutorials/learn_bivariate_normal.ipynb`, making a few edits along the way.

The other two tutorials on the theory of univariate and multivariate bijections will be converted in a separate PR.

### Test Plan
Run `tutorials/learn_bivariate_normal.ipynb` via Jupyter notebook on your system.