### PR TITLE
Fixed bug in `bijectors.ops.spline.Spline` and unit test for log(detJ))

### DIFF
--- a/flowtorch/bijectors/ops/spline.py
+++ b/flowtorch/bijectors/ops/spline.py
@@ -53,10 +53,7 @@ class Spline(Bijector):
         self, y: torch.Tensor, params: Optional[Sequence[torch.Tensor]]
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         x_new, log_detJ = self._op(y, params, inverse=True)
-
-        # TODO: Should I invert the sign of log_detJ?
-        # TODO: A unit test that compares log_detJ from _forward and _inverse
-        return x_new, _sum_rightmost(log_detJ, self.domain.event_dim)
+        return x_new, _sum_rightmost(-log_detJ, self.domain.event_dim)
 
     def _log_abs_det_jacobian(
         self,

--- a/tests/test_bijector.py
+++ b/tests/test_bijector.py
@@ -108,12 +108,16 @@ def test_inverse(flow, epsilon=1e-5):
     x_true = torch.distributions.transform_to(bij.domain)(x_true)
 
     y = bij.forward(x_true)
+    J_1 = y.log_detJ
+    y = y.detach_from_flow()
+
     x_calculated = bij.inverse(y)
+    J_2 = x_calculated.log_detJ
+    x_calculated = x_calculated.detach_from_flow()
+
     assert (x_true - x_calculated).abs().max().item() < epsilon
 
     # Test that Jacobian after inverse op is same as after forward
-    J_1 = bij.log_abs_det_jacobian(x_true, y)
-    J_2 = bij.log_abs_det_jacobian(x_calculated, y)
     assert (J_1 - J_2).abs().max().item() < epsilon
 
 


### PR DESCRIPTION
### Motivation
From other work, I discovered that training Neural Spline Flows was not working as expected, being unable to learn simple toy distributions... This PR fixes this, as well as the reason that the unit tests were not picking it up.

### Changes proposed
I changed the sign of the `log(det(J))` in the `inverse` method of `bijectors.ops.spline.Spline`, and ensured the unit tests are not using cached values of `log(det(J))` (via `BijectiveTensor`) when comparing `log(det(J))` from the forward method to that of the inverse one.

### Test Plan
Run `pytest tests/` and try the Neural Spline Flow example in the theory tutorials